### PR TITLE
Added endpoint POST /v1/idp/connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ java -version
 
 Ensure that **Java 17** is the active version in use. Maven should also be configured to use Java 17 - you can verify this by checking that `mvn --version` shows Java 17 in its output.
 
-Additionally, make sure the following ports are free and not in use by other services:
+Additionally, make sure the following ports are free and not in use by other services :
 
 * `3306` – MySQL
 * `6379` – Redis

--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/OidcProviderConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/OidcProviderConfig.java
@@ -1,0 +1,28 @@
+package com.dreamsportslabs.guardian.config.tenant;
+
+import com.dreamsportslabs.guardian.constant.ClientAuthMethod;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class OidcProviderConfig {
+  private String tenantId;
+  private String providerName;
+  private String issuer;
+  private String jwksUrl;
+  private String tokenUrl;
+  private String clientId;
+  private String clientSecret;
+  private String redirectUri;
+  private ClientAuthMethod clientAuthMethod;
+  private Boolean isSslEnabled;
+  private String userIdentifier;
+  private Map<String, Object> audienceClaims;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/TenantConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/TenantConfig.java
@@ -1,5 +1,6 @@
 package com.dreamsportslabs.guardian.config.tenant;
 
+import java.util.Map;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -18,4 +19,5 @@ public class TenantConfig {
   private UserConfig userConfig;
   private TokenConfig tokenConfig;
   private ContactVerifyConfig contactVerifyConfig;
+  private Map<String, OidcProviderConfig> oidcProviderConfig;
 }

--- a/src/main/java/com/dreamsportslabs/guardian/constant/ClientAuthMethod.java
+++ b/src/main/java/com/dreamsportslabs/guardian/constant/ClientAuthMethod.java
@@ -1,0 +1,15 @@
+package com.dreamsportslabs.guardian.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum ClientAuthMethod {
+  BASIC("client_secret_basic"),
+  POST("client_secret_post");
+
+  private final String value;
+
+  ClientAuthMethod(String clientAuthMethod) {
+    this.value = clientAuthMethod;
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/constant/Constants.java
+++ b/src/main/java/com/dreamsportslabs/guardian/constant/Constants.java
@@ -27,6 +27,7 @@ public final class Constants {
   public static final String OIDC_CLAIMS_FAMILY_NAME = "family_name";
   public static final String OIDC_CLAIMS_MIDDLE_NAME = "middle_name";
   public static final String OIDC_CLAIMS_PICTURE = "picture";
+  public static final String OIDC_CLAIMS_PHONE = "phone_number";
 
   public static final String EXPIRY_OPTION_REDIS = "EX";
   public static final String EXPIRE_AT_REDIS = "EXAT";
@@ -55,6 +56,7 @@ public final class Constants {
   public static final String JWT_CLAIMS_IAT = "iat";
   public static final String JWT_CLAIMS_EXP = "exp";
   public static final String JWT_CLAIMS_RFT_ID = "rft_id";
+  public static final String JWT_CLAIMS_AUD = "aud";
 
   public static final ImmutableList<String> fbAuthResponseTypes = ImmutableList.of(CODE, TOKEN);
   public static final ImmutableList<String> passwordlessAuthResponseTypes =
@@ -77,7 +79,7 @@ public final class Constants {
   public static final String USER_FILTERS_EMAIL = "email";
   public static final String USER_FILTERS_PHONE = "phoneNumber";
   public static final String USER_FILTERS_PROVIDER_NAME = "providerName";
-  public static final String USER_FILTERS_PROVIDER_USER_ID = "providerId";
+  public static final String USER_FILTERS_PROVIDER_USER_ID = "providerUserId";
 
   public static final String CACHE_KEY_CODE = "CODE";
   public static final String CACHE_KEY_STATE = "STATE";
@@ -102,6 +104,8 @@ public final class Constants {
   public static final String UNAUTHORIZED_ERROR_CODE = "unauthorized";
   public static final String OTP_RESEND_AFTER = "resendAfter";
   public static final String OTP_RETRIES_LEFT = "retriesLeft";
+  public static final String ERROR = "error";
+  public static final String ERROR_DESCRIPTION = "error_description";
 
   public static final String MESSAGE_CHANNEL = "channel";
   public static final String MESSAGE_TO = "to";
@@ -112,4 +116,25 @@ public final class Constants {
   public static final String FORMAT_PEM = "PEM";
   public static final String FORMAT_JWKS = "JWKS";
   public static final ImmutableList<Integer> VALID_KEY_SIZES = ImmutableList.of(2048, 3072, 4096);
+
+  // OIDC Token Constants
+  public static final String OIDC_REFRESH_TOKEN = "refresh_token";
+  public static final String AUTHORIZATION = "Authorization";
+  public static final String OIDC_GRANT_TYPE = "grant_type";
+  public static final String OIDC_AUTHORIZATION_CODE = "authorization_code";
+  public static final String OIDC_REDIRECT_URI = "redirect_uri";
+  public static final String OIDC_CODE_VERIFIER = "code_verifier";
+  public static final String OIDC_CODE = "code";
+  public static final String OIDC_CLIENT_ID = "client_id";
+  public static final String OIDC_CLIENT_SECRET = "client_secret";
+  public static final String OIDC_CLIENT_AUTH_METHOD_POST = "client_secret_post";
+  public static final String OIDC_CLIENT_AUTH_METHOD_BASIC = "client_secret_basic";
+  public static final String FLOW_SIGNINUP = "SIGNINUP";
+
+  public static final String APP_CODE = "code";
+  public static final String APP_ACCESS_TOKEN = "accessToken";
+  public static final String APP_REFRESH_TOKEN = "refreshToken";
+  public static final String APP_ID_TOKEN = "idToken";
+  public static final String APP_TOKEN_TYPE = "tokenType";
+  public static final String APP_TOKEN_CODE_EXPIRY = "expiresIn";
 }

--- a/src/main/java/com/dreamsportslabs/guardian/constant/IdpUserIdentifier.java
+++ b/src/main/java/com/dreamsportslabs/guardian/constant/IdpUserIdentifier.java
@@ -1,0 +1,25 @@
+package com.dreamsportslabs.guardian.constant;
+
+import lombok.Getter;
+
+@Getter
+public enum IdpUserIdentifier {
+  EMAIL("email"),
+  PHONE("phone"),
+  SUB("sub");
+
+  private final String value;
+
+  IdpUserIdentifier(String value) {
+    this.value = value;
+  }
+
+  public static IdpUserIdentifier fromString(String value) {
+    for (IdpUserIdentifier identifier : IdpUserIdentifier.values()) {
+      if (identifier.value.equals(value)) {
+        return identifier;
+      }
+    }
+    return EMAIL;
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dao/model/IdpCredentials.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/model/IdpCredentials.java
@@ -1,0 +1,12 @@
+package com.dreamsportslabs.guardian.dao.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class IdpCredentials {
+  private String accessToken;
+  private String refreshToken;
+  private String idToken;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dao/query/ConfigQuery.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/query/ConfigQuery.java
@@ -106,4 +106,22 @@ public class ConfigQuery {
        FROM contact_verify_config
        WHERE tenant_id = ?
     """;
+
+  public static final String OIDC_PROVIDER_CONFIG =
+      """
+    SELECT tenant_id,
+           provider_name,
+           issuer,
+           jwks_url,
+           token_url,
+           client_id,
+           client_secret,
+           redirect_uri,
+           client_auth_method,
+           is_ssl_enabled,
+           user_identifier,
+           audience_claims
+    FROM oidc_provider_config
+    WHERE tenant_id = ?
+    """;
 }

--- a/src/main/java/com/dreamsportslabs/guardian/dto/request/IdpConnectRequestDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/request/IdpConnectRequestDto.java
@@ -1,0 +1,80 @@
+package com.dreamsportslabs.guardian.dto.request;
+
+import static com.dreamsportslabs.guardian.constant.Constants.FLOW_SIGNINUP;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INVALID_REQUEST;
+
+import com.dreamsportslabs.guardian.constant.Flow;
+import com.dreamsportslabs.guardian.constant.ResponseType;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.lang3.StringUtils;
+
+@Setter
+@Getter
+public class IdpConnectRequestDto {
+  private String idProvider;
+  private String identifier;
+  private String responseType;
+  private String nonce;
+  private String codeVerifier;
+  private String flow;
+  private MetaInfo metaInfo;
+  @JsonIgnore private Map<String, Object> additionalInfo;
+  @JsonIgnore private ResponseType idpResponseType;
+  @JsonIgnore private Flow loginFlow;
+
+  @JsonAnyGetter
+  public Map<String, Object> getAdditionalInfo() {
+    return this.additionalInfo;
+  }
+
+  @JsonAnySetter
+  public void addAdditionalInfo(String key, Object value) {
+    this.additionalInfo.put(key, value);
+  }
+
+  public IdpConnectRequestDto() {
+    this.loginFlow = Flow.SIGNINUP;
+    this.metaInfo = new MetaInfo();
+    this.additionalInfo = new HashMap<>();
+  }
+
+  public void validate() {
+    if (StringUtils.isBlank(idProvider)) {
+      throw INVALID_REQUEST.getCustomException("idProvider is required");
+    }
+
+    if (StringUtils.isBlank(identifier)) {
+      throw INVALID_REQUEST.getCustomException("identifier is required");
+    }
+
+    if (StringUtils.isBlank(responseType)) {
+      throw INVALID_REQUEST.getCustomException("response type is required");
+    }
+
+    setIdpResponseType();
+    setLoginFlow();
+  }
+
+  private void setIdpResponseType() {
+    try {
+      this.idpResponseType = ResponseType.valueOf(responseType.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw INVALID_REQUEST.getCustomException("Unsupported response_type: '" + responseType + "'");
+    }
+  }
+
+  private void setLoginFlow() {
+    try {
+      String flowValue = StringUtils.isBlank(flow) ? FLOW_SIGNINUP : flow.toUpperCase();
+      this.loginFlow = Flow.valueOf(flowValue);
+    } catch (IllegalArgumentException e) {
+      throw INVALID_REQUEST.getCustomException("Unsupported flow: '" + flow + "'");
+    }
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dto/response/IdpConnectResponseDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/response/IdpConnectResponseDto.java
@@ -1,0 +1,43 @@
+package com.dreamsportslabs.guardian.dto.response;
+
+import static com.dreamsportslabs.guardian.constant.Constants.APP_ACCESS_TOKEN;
+import static com.dreamsportslabs.guardian.constant.Constants.APP_CODE;
+import static com.dreamsportslabs.guardian.constant.Constants.APP_ID_TOKEN;
+import static com.dreamsportslabs.guardian.constant.Constants.APP_REFRESH_TOKEN;
+import static com.dreamsportslabs.guardian.constant.Constants.APP_TOKEN_CODE_EXPIRY;
+import static com.dreamsportslabs.guardian.constant.Constants.APP_TOKEN_TYPE;
+
+import com.dreamsportslabs.guardian.dao.model.IdpCredentials;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.vertx.core.json.JsonObject;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class IdpConnectResponseDto {
+  private String code;
+  private String accessToken;
+  private String refreshToken;
+  private String idToken;
+  private String tokenType;
+  private Integer expiresIn;
+  private Boolean isNewUser;
+  private IdpCredentials idpCredentials;
+
+  public static IdpConnectResponseDto buildIdpConnectResponse(
+      Object authResponse, Boolean isNewUser, IdpCredentials idpTokens) {
+    JsonObject responseJson = JsonObject.mapFrom(authResponse);
+
+    return new IdpConnectResponseDto(
+        responseJson.getString(APP_CODE),
+        responseJson.getString(APP_ACCESS_TOKEN),
+        responseJson.getString(APP_REFRESH_TOKEN),
+        responseJson.getString(APP_ID_TOKEN),
+        responseJson.getString(APP_TOKEN_TYPE),
+        responseJson.getInteger(APP_TOKEN_CODE_EXPIRY),
+        isNewUser,
+        idpTokens);
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/exception/ErrorEnum.java
+++ b/src/main/java/com/dreamsportslabs/guardian/exception/ErrorEnum.java
@@ -25,7 +25,18 @@ public enum ErrorEnum {
   RETRIES_EXHAUSTED("retries_exhausted", "Retries exhausted", 400),
 
   USER_EXISTS("user_exists", "User already exists", 400),
-  USER_NOT_EXISTS("user_not_exists", "User does not exist", 400);
+  USER_NOT_EXISTS("user_not_exists", "User does not exist", 400),
+
+  INVALID_IDP_TOKEN("invalid_idp_token", "Invalid identity provider token", 400),
+  INVALID_IDP_CODE("invalid_idp_code", "Missing ID token in provider response", 400),
+  PROVIDER_TOKENS_EXCHANGE_FAILED(
+      "token_exchange_failed",
+      "Error occurred while exchanging authorization_code for provider tokens",
+      400),
+  INVALID_USER_IDENTIFIER(
+      "invalid_user_identifier",
+      "No valid user identifier found from the identifier provided",
+      400);
 
   private final String code;
   private final String message;
@@ -76,6 +87,15 @@ public enum ErrorEnum {
         Response.status(this.httpStatusCode)
             .header("Content-Type", "application/json")
             .entity(new ErrorEntity(this.code, message, data))
+            .build();
+    return new WebApplicationException(response);
+  }
+
+  public WebApplicationException getCustomException(String code, String message) {
+    Response response =
+        Response.status(this.httpStatusCode)
+            .header("Content-Type", "application/json")
+            .entity(new ErrorEntity(code, message))
             .build();
     return new WebApplicationException(response);
   }

--- a/src/main/java/com/dreamsportslabs/guardian/rest/IdpConnect.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/IdpConnect.java
@@ -1,0 +1,52 @@
+package com.dreamsportslabs.guardian.rest;
+
+import static com.dreamsportslabs.guardian.constant.Constants.TENANT_ID;
+
+import com.dreamsportslabs.guardian.dto.request.IdpConnectRequestDto;
+import com.dreamsportslabs.guardian.service.AuthorizationService;
+import com.dreamsportslabs.guardian.service.IdpConnectService;
+import com.google.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.concurrent.CompletionStage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+@Path("/v1/idp/connect")
+public class IdpConnect {
+  private final IdpConnectService idpConnectService;
+  private final AuthorizationService authorizationService;
+
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public CompletionStage<Response> connect(
+      @Context HttpHeaders headers,
+      @HeaderParam(TENANT_ID) String tenantId,
+      IdpConnectRequestDto requestDto) {
+    requestDto.validate();
+    return idpConnectService
+        .connect(requestDto, headers.getRequestHeaders(), tenantId)
+        .map(
+            response -> {
+              if (StringUtils.isNotBlank(response.getCode())) {
+                return Response.ok(response).build();
+              } else {
+                return Response.ok(response)
+                    .cookie(authorizationService.getIDPConnectCookies(response, tenantId))
+                    .build();
+              }
+            })
+        .toCompletionStage();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/service/AuthorizationService.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/AuthorizationService.java
@@ -24,6 +24,7 @@ import com.dreamsportslabs.guardian.dto.request.V1CodeTokenExchangeRequestDto;
 import com.dreamsportslabs.guardian.dto.request.V1LogoutRequestDto;
 import com.dreamsportslabs.guardian.dto.request.V1RefreshTokenRequestDto;
 import com.dreamsportslabs.guardian.dto.response.CodeResponseDto;
+import com.dreamsportslabs.guardian.dto.response.IdpConnectResponseDto;
 import com.dreamsportslabs.guardian.dto.response.RefreshTokenResponseDto;
 import com.dreamsportslabs.guardian.dto.response.TokenResponseDto;
 import com.dreamsportslabs.guardian.registry.Registry;
@@ -60,6 +61,12 @@ public class AuthorizationService {
   }
 
   public NewCookie[] getCookies(TokenResponseDto responseDto, String tenantId) {
+    NewCookie accessTokenCookie = getAccessTokenCookie(responseDto.getAccessToken(), tenantId);
+    NewCookie refreshTokenCookie = getRefreshTokenCookie(responseDto.getRefreshToken(), tenantId);
+    return new NewCookie[] {accessTokenCookie, refreshTokenCookie};
+  }
+
+  public NewCookie[] getIDPConnectCookies(IdpConnectResponseDto responseDto, String tenantId) {
     NewCookie accessTokenCookie = getAccessTokenCookie(responseDto.getAccessToken(), tenantId);
     NewCookie refreshTokenCookie = getRefreshTokenCookie(responseDto.getRefreshToken(), tenantId);
     return new NewCookie[] {accessTokenCookie, refreshTokenCookie};

--- a/src/main/java/com/dreamsportslabs/guardian/service/IdpConnectService.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/IdpConnectService.java
@@ -1,0 +1,308 @@
+package com.dreamsportslabs.guardian.service;
+
+import static com.dreamsportslabs.guardian.constant.Constants.AUTHORIZATION;
+import static com.dreamsportslabs.guardian.constant.Constants.ERROR;
+import static com.dreamsportslabs.guardian.constant.Constants.ERROR_DESCRIPTION;
+import static com.dreamsportslabs.guardian.constant.Constants.JWT_CLAIMS_SUB;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_AUTHORIZATION_CODE;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_CLAIMS_EMAIL;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_CLAIMS_FAMILY_NAME;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_CLAIMS_FULL_NAME;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_CLAIMS_GIVEN_NAME;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_CLAIMS_PHONE;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_CLIENT_AUTH_METHOD_BASIC;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_CLIENT_AUTH_METHOD_POST;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_CLIENT_ID;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_CLIENT_SECRET;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_CODE;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_CODE_VERIFIER;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_GRANT_TYPE;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_REDIRECT_URI;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_REFRESH_TOKEN;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_TOKENS_ACCESS_TOKEN;
+import static com.dreamsportslabs.guardian.constant.Constants.OIDC_TOKENS_ID_TOKEN;
+import static com.dreamsportslabs.guardian.constant.Constants.USERID;
+import static com.dreamsportslabs.guardian.constant.Constants.USER_FILTERS_EMAIL;
+import static com.dreamsportslabs.guardian.constant.Constants.USER_FILTERS_PHONE;
+import static com.dreamsportslabs.guardian.constant.Constants.USER_FILTERS_PROVIDER_NAME;
+import static com.dreamsportslabs.guardian.constant.Constants.USER_FILTERS_PROVIDER_USER_ID;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INTERNAL_SERVER_ERROR;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INVALID_IDP_CODE;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INVALID_IDP_TOKEN;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.PROVIDER_TOKENS_EXCHANGE_FAILED;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.USER_EXISTS;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.USER_NOT_EXISTS;
+
+import com.dreamsportslabs.guardian.config.tenant.OidcProviderConfig;
+import com.dreamsportslabs.guardian.config.tenant.TenantConfig;
+import com.dreamsportslabs.guardian.constant.Flow;
+import com.dreamsportslabs.guardian.constant.IdpUserIdentifier;
+import com.dreamsportslabs.guardian.dao.model.IdpCredentials;
+import com.dreamsportslabs.guardian.dto.Provider;
+import com.dreamsportslabs.guardian.dto.UserDto;
+import com.dreamsportslabs.guardian.dto.request.IdpConnectRequestDto;
+import com.dreamsportslabs.guardian.dto.response.IdpConnectResponseDto;
+import com.dreamsportslabs.guardian.exception.ErrorEnum;
+import com.dreamsportslabs.guardian.registry.Registry;
+import com.dreamsportslabs.guardian.utils.Utils;
+import com.google.inject.Inject;
+import io.reactivex.rxjava3.core.Single;
+import io.vertx.core.json.JsonObject;
+import io.vertx.rxjava3.core.MultiMap;
+import io.vertx.rxjava3.core.buffer.Buffer;
+import io.vertx.rxjava3.ext.web.client.HttpRequest;
+import io.vertx.rxjava3.ext.web.client.WebClient;
+import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class IdpConnectService {
+  private final UserService userService;
+  private final AuthorizationService authorizationService;
+  private final WebClient webClient;
+  private final Registry registry;
+
+  public Single<IdpConnectResponseDto> connect(
+      IdpConnectRequestDto requestDto, MultivaluedMap<String, String> headers, String tenantId) {
+
+    TenantConfig tenantConfig = registry.get(tenantId, TenantConfig.class);
+    String providerName = requestDto.getIdProvider();
+    OidcProviderConfig oidcProviderConfig = tenantConfig.getOidcProviderConfig().get(providerName);
+
+    if (oidcProviderConfig == null) {
+      return Single.error(
+          ErrorEnum.INVALID_REQUEST.getCustomException(
+              "Specified provider is not configured for tenant"));
+    }
+
+    String userIdentifier = oidcProviderConfig.getUserIdentifier();
+
+    return exchangeCodeForTokens(requestDto, oidcProviderConfig)
+        .flatMap(
+            idpTokens -> {
+              Provider provider = createProviderFromTokens(idpTokens, providerName);
+              UserDto userDto = createUserDtoFromTokens(provider);
+              Map<String, String> queryParams =
+                  getUserIdentifierDetails(userIdentifier, userDto, requestDto.getIdProvider());
+              return processUserBasedOnFlow(
+                      queryParams, userDto, requestDto.getLoginFlow(), headers, tenantId)
+                  .flatMap(
+                      userJson ->
+                          authorizationService
+                              .generate(
+                                  userJson,
+                                  requestDto.getIdpResponseType().getResponseType(),
+                                  requestDto.getMetaInfo(),
+                                  tenantId)
+                              .map(
+                                  responseDto -> {
+                                    Boolean isNewUser =
+                                        (Boolean) userJson.getValue("isNewUser", false);
+                                    return IdpConnectResponseDto.buildIdpConnectResponse(
+                                        responseDto, isNewUser, idpTokens);
+                                  }));
+            });
+  }
+
+  private Provider createProviderFromTokens(IdpCredentials idpTokens, String providerName) {
+    Map<String, Object> claims = decodeJwtPayload(idpTokens.getIdToken());
+    Object userIdClaim = claims.get(JWT_CLAIMS_SUB);
+    String providerUserId = userIdClaim != null ? userIdClaim.toString() : null;
+
+    Map<String, Object> credentials = new HashMap<>();
+    credentials.put(OIDC_TOKENS_ACCESS_TOKEN, idpTokens.getAccessToken());
+    credentials.put(OIDC_REFRESH_TOKEN, idpTokens.getRefreshToken());
+
+    return Provider.builder()
+        .name(providerName)
+        .data(claims)
+        .providerUserId(providerUserId)
+        .credentials(credentials)
+        .build();
+  }
+
+  private Map<String, Object> decodeJwtPayload(String jwt) {
+    try {
+      String[] parts = jwt.split("\\.");
+      if (parts.length != 3) {
+        throw INVALID_IDP_TOKEN.getCustomException("Invalid JWT format");
+      }
+      String payloadJson = new String(Base64.getUrlDecoder().decode(parts[1]));
+      return new JsonObject(payloadJson).getMap();
+    } catch (Exception e) {
+      throw INTERNAL_SERVER_ERROR.getCustomException("Failed to decode JWT payload");
+    }
+  }
+
+  private UserDto createUserDtoFromTokens(Provider provider) {
+    Map<String, Object> claims = provider.getData();
+
+    UserDto.UserDtoBuilder userDtoBuilder = UserDto.builder();
+    if (claims.containsKey(OIDC_CLAIMS_GIVEN_NAME)) {
+      userDtoBuilder.firstName(claims.get(OIDC_CLAIMS_GIVEN_NAME).toString());
+    }
+    if (claims.containsKey(OIDC_CLAIMS_FAMILY_NAME)) {
+      userDtoBuilder.lastName(claims.get(OIDC_CLAIMS_FAMILY_NAME).toString());
+    }
+    if (claims.containsKey(OIDC_CLAIMS_FULL_NAME)) {
+      userDtoBuilder.name(claims.get(OIDC_CLAIMS_FULL_NAME).toString());
+    }
+    if (claims.containsKey(OIDC_CLAIMS_EMAIL)) {
+      userDtoBuilder.email(claims.get(OIDC_CLAIMS_EMAIL).toString());
+    }
+    if (claims.containsKey(OIDC_CLAIMS_PHONE)) {
+      userDtoBuilder.phoneNumber(claims.get(OIDC_CLAIMS_PHONE).toString());
+    }
+    userDtoBuilder.provider(provider);
+
+    return userDtoBuilder.build();
+  }
+
+  private Map<String, String> getUserIdentifierDetails(
+      String userIdentifier, UserDto userDto, String idProvider) {
+
+    Map<String, String> queryParams = new HashMap<>();
+    boolean isUserIdentifierExists;
+
+    IdpUserIdentifier identifierType = IdpUserIdentifier.fromString(userIdentifier);
+
+    switch (identifierType) {
+      case PHONE:
+        isUserIdentifierExists = StringUtils.isNotBlank(userDto.getPhoneNumber());
+        queryParams.put(USER_FILTERS_PHONE, userDto.getPhoneNumber());
+        break;
+      case SUB:
+        isUserIdentifierExists = StringUtils.isNotBlank(userDto.getProvider().getProviderUserId());
+        queryParams.put(USER_FILTERS_PROVIDER_USER_ID, userDto.getProvider().getProviderUserId());
+        queryParams.put(USER_FILTERS_PROVIDER_NAME, idProvider);
+        break;
+      default:
+        isUserIdentifierExists = StringUtils.isNotBlank(userDto.getEmail());
+        queryParams.put(USER_FILTERS_EMAIL, userDto.getEmail());
+    }
+
+    if (!isUserIdentifierExists) {
+      throw ErrorEnum.INVALID_USER_IDENTIFIER.getException();
+    }
+
+    return queryParams;
+  }
+
+  private Single<JsonObject> processUserBasedOnFlow(
+      Map<String, String> queryParams,
+      UserDto userDto,
+      Flow flow,
+      MultivaluedMap<String, String> headers,
+      String tenantId) {
+
+    return userService
+        .getUser(queryParams, headers, tenantId)
+        .flatMap(
+            user -> {
+              boolean userExists = user.getString(USERID) != null;
+
+              switch (flow) {
+                case SIGNIN:
+                  if (!userExists) {
+                    return Single.error(USER_NOT_EXISTS.getCustomException("User does not exist"));
+                  }
+                  return userService
+                      .addProvider(user.getString(USERID), headers, userDto.getProvider(), tenantId)
+                      .andThen(Single.just(user));
+
+                case SIGNUP:
+                  if (userExists) {
+                    return Single.error(USER_EXISTS.getCustomException("User already exists"));
+                  }
+                  return userService.createUser(userDto, headers, tenantId);
+
+                case SIGNINUP:
+                  if (userExists) {
+                    return userService
+                        .addProvider(
+                            user.getString(USERID), headers, userDto.getProvider(), tenantId)
+                        .andThen(Single.just(user));
+                  } else {
+                    return userService.createUser(userDto, headers, tenantId);
+                  }
+
+                default:
+                  return userService
+                      .addProvider(user.getString(USERID), headers, userDto.getProvider(), tenantId)
+                      .andThen(Single.just(user));
+              }
+            });
+  }
+
+  public Single<IdpCredentials> exchangeCodeForTokens(
+      IdpConnectRequestDto requestDto, OidcProviderConfig oidcProviderConfig) {
+
+    MultiMap oidcTokenRequestBody = buildTokenExchangeRequest(requestDto, oidcProviderConfig);
+
+    HttpRequest<Buffer> httpRequest =
+        webClient
+            .postAbs(oidcProviderConfig.getTokenUrl())
+            .ssl(oidcProviderConfig.getIsSslEnabled());
+
+    if (oidcProviderConfig.getClientAuthMethod().getValue().equals(OIDC_CLIENT_AUTH_METHOD_BASIC)) {
+      httpRequest =
+          httpRequest.putHeader(
+              AUTHORIZATION,
+              Utils.generateBasicAuthHeader(
+                  oidcProviderConfig.getClientId(), oidcProviderConfig.getClientSecret()));
+    }
+
+    return initiateTokenExchange(httpRequest, oidcTokenRequestBody);
+  }
+
+  public MultiMap buildTokenExchangeRequest(
+      IdpConnectRequestDto requestDto, OidcProviderConfig oidcProviderConfig) {
+    MultiMap oidcTokenRequestBody = MultiMap.caseInsensitiveMultiMap();
+    oidcTokenRequestBody.add(OIDC_GRANT_TYPE, OIDC_AUTHORIZATION_CODE);
+    oidcTokenRequestBody.add(OIDC_CODE, requestDto.getIdentifier());
+    oidcTokenRequestBody.add(OIDC_REDIRECT_URI, oidcProviderConfig.getRedirectUri());
+    if (StringUtils.isNotBlank(requestDto.getCodeVerifier())) {
+      oidcTokenRequestBody.add(OIDC_CODE_VERIFIER, requestDto.getCodeVerifier());
+    }
+    if (oidcProviderConfig.getClientAuthMethod().getValue().equals(OIDC_CLIENT_AUTH_METHOD_POST)) {
+      oidcTokenRequestBody.add(OIDC_CLIENT_ID, oidcProviderConfig.getClientId());
+      oidcTokenRequestBody.add(OIDC_CLIENT_SECRET, oidcProviderConfig.getClientSecret());
+    }
+    return oidcTokenRequestBody;
+  }
+
+  public Single<IdpCredentials> initiateTokenExchange(
+      HttpRequest<Buffer> httpRequest, MultiMap oidcTokenRequestBody) {
+    return httpRequest
+        .rxSendForm(oidcTokenRequestBody)
+        .onErrorResumeNext(
+            err -> Single.error(INTERNAL_SERVER_ERROR.getCustomException(err.getMessage())))
+        .map(
+            res -> {
+              if (res.statusCode() == 200) {
+                JsonObject jsonBody = res.bodyAsJsonObject();
+                if (StringUtils.isNotBlank(jsonBody.getString(OIDC_TOKENS_ID_TOKEN))) {
+                  return IdpCredentials.builder()
+                      .accessToken(jsonBody.getString(OIDC_TOKENS_ACCESS_TOKEN))
+                      .refreshToken(jsonBody.getString(OIDC_REFRESH_TOKEN))
+                      .idToken(jsonBody.getString(OIDC_TOKENS_ID_TOKEN))
+                      .build();
+                } else {
+                  throw INVALID_IDP_CODE.getException();
+                }
+              } else if (res.statusCode() >= 400 && res.statusCode() < 500) {
+                String errorDescription = res.bodyAsJsonObject().getString(ERROR);
+                String error = res.bodyAsJsonObject().getString(ERROR_DESCRIPTION);
+                throw PROVIDER_TOKENS_EXCHANGE_FAILED.getCustomException(error, errorDescription);
+              } else {
+                throw INTERNAL_SERVER_ERROR.getCustomException("Token exchange failed");
+              }
+            });
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/utils/Utils.java
+++ b/src/main/java/com/dreamsportslabs/guardian/utils/Utils.java
@@ -4,6 +4,7 @@ import static com.dreamsportslabs.guardian.constant.Constants.prohibitedForwardi
 
 import io.vertx.rxjava3.core.MultiMap;
 import jakarta.ws.rs.core.MultivaluedMap;
+import java.util.Base64;
 import java.util.regex.Pattern;
 import org.apache.commons.codec.digest.DigestUtils;
 
@@ -36,5 +37,10 @@ public final class Utils {
 
   public static String getMd5Hash(String input) {
     return DigestUtils.md5Hex(input).toUpperCase();
+  }
+
+  public static String generateBasicAuthHeader(String clientId, String clientSecret) {
+    return "Basic "
+        + new String(Base64.getEncoder().encode((clientId + ":" + clientSecret).getBytes()));
   }
 }

--- a/src/main/resources/migrations/01_migrationFile.sql
+++ b/src/main/resources/migrations/01_migrationFile.sql
@@ -222,3 +222,27 @@ CREATE TABLE contact_verify_config
 ) ENGINE = InnoDB
   DEFAULT CHARSET = utf8mb4
   COLLATE = utf8mb4_0900_ai_ci;
+
+
+CREATE TABLE oidc_provider_config
+(
+    tenant_id          CHAR(10)      NOT NULL,
+    provider_name      VARCHAR(50)   NOT NULL,
+    issuer             VARCHAR(2083) NOT NULL,
+    jwks_url           VARCHAR(2083) NOT NULL,
+    token_url          VARCHAR(2083) NOT NULL,
+    client_id          VARCHAR(256)  NOT NULL,
+    client_secret      TEXT          NOT NULL,
+    redirect_uri       VARCHAR(2083) NOT NULL,
+    client_auth_method VARCHAR(256)  NOT NULL,
+    is_ssl_enabled     BOOLEAN       NOT NULL DEFAULT TRUE,
+    user_identifier    VARCHAR(20)   NOT NULL DEFAULT 'email',
+    audience_claims    JSON          NOT NULL,
+    created_at         TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at         TIMESTAMP     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_tenant_oidc_provider_config FOREIGN KEY (tenant_id)
+        REFERENCES tenant (id) ON DELETE CASCADE,
+    PRIMARY KEY `idx_tenant_provider` (`tenant_id`, `provider_name`)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;


### PR DESCRIPTION
# Generic IDP Login API

## 📋 Summary

This PR introduces a new REST API endpoint, `/v1/idp/connect`, for generic IDP login support.

## 🚀 Features Added

### **New API Endpoint**
• **POST** /v1/idp/connect

## 🔍 API cURL Example
```
curl --location 'localhost:8080/v1/idp/connect' \
--header 'tenant-id: tenant1' \
--header 'Content-Type: application/json' \
--data '{
    "idProvider": "Google",
    "identifier": "cd1b1c938d2akjbcds687asdbak923b8.0.sruxt.e8I7gPskq-7Jl36tADWWlQ",
    "responseType": "token",
    "flow": "SIGNINUP",
    "metaInfo": {
        "deviceName": "string",
        "location": "string",
        "source": "string",
        "ip": "192.168.1.1"
    }
}'

```