### PR TITLE
feat: add RSA key generation API functionality

### DIFF
--- a/src/main/java/com/dreamsportslabs/guardian/constant/Constants.java
+++ b/src/main/java/com/dreamsportslabs/guardian/constant/Constants.java
@@ -3,7 +3,6 @@ package com.dreamsportslabs.guardian.constant;
 import com.google.common.collect.ImmutableList;
 import io.vertx.core.json.JsonObject;
 import java.util.ArrayList;
-import java.util.Set;
 
 public final class Constants {
   public static final String TENANT_ID = "tenant-id";
@@ -112,5 +111,5 @@ public final class Constants {
 
   public static final String FORMAT_PEM = "PEM";
   public static final String FORMAT_JWKS = "JWKS";
-  public static final Set<Integer> VALID_KEY_SIZES = Set.of(2048, 3072, 4096);
+  public static final ImmutableList<Integer> VALID_KEY_SIZES = ImmutableList.of(2048, 3072, 4096);
 }

--- a/src/main/java/com/dreamsportslabs/guardian/constant/Constants.java
+++ b/src/main/java/com/dreamsportslabs/guardian/constant/Constants.java
@@ -3,6 +3,7 @@ package com.dreamsportslabs.guardian.constant;
 import com.google.common.collect.ImmutableList;
 import io.vertx.core.json.JsonObject;
 import java.util.ArrayList;
+import java.util.Set;
 
 public final class Constants {
   public static final String TENANT_ID = "tenant-id";
@@ -108,4 +109,8 @@ public final class Constants {
   public static final String MESSAGE_TEMPLATE_NAME = "templateName";
   public static final String MESSAGE_TEMPLATE_PARAMS = "templateParams";
   public static final String MESSAGE_TEMPLATE_PARAMS_OTP = "otp";
+
+  public static final String FORMAT_PEM = "PEM";
+  public static final String FORMAT_JWKS = "JWKS";
+  public static final Set<Integer> VALID_KEY_SIZES = Set.of(2048, 3072, 4096);
 }

--- a/src/main/java/com/dreamsportslabs/guardian/dto/request/GenerateRsaKeyRequestDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/request/GenerateRsaKeyRequestDto.java
@@ -15,10 +15,7 @@ public class GenerateRsaKeyRequestDto {
   private String format = FORMAT_PEM;
 
   public void validate() {
-    // Validate key size
-    if (keySize == null) {
-      keySize = 2048;
-    } else if (!VALID_KEY_SIZES.contains(keySize)) {
+    if (!VALID_KEY_SIZES.contains(keySize)) {
       throw INVALID_REQUEST.getCustomException(
           "Invalid RSA key length. Allowed values are [2048, 3072, 4096]");
     }

--- a/src/main/java/com/dreamsportslabs/guardian/dto/request/GenerateRsaKeyRequestDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/request/GenerateRsaKeyRequestDto.java
@@ -1,0 +1,32 @@
+package com.dreamsportslabs.guardian.dto.request;
+
+import static com.dreamsportslabs.guardian.constant.Constants.FORMAT_JWKS;
+import static com.dreamsportslabs.guardian.constant.Constants.FORMAT_PEM;
+import static com.dreamsportslabs.guardian.constant.Constants.VALID_KEY_SIZES;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.INVALID_REQUEST;
+
+import lombok.Data;
+import org.apache.commons.lang3.StringUtils;
+
+@Data
+public class GenerateRsaKeyRequestDto {
+
+  private Integer keySize = 2048;
+  private String format = FORMAT_PEM;
+
+  public void validate() {
+    // Validate key size
+    if (keySize == null) {
+      keySize = 2048;
+    } else if (!VALID_KEY_SIZES.contains(keySize)) {
+      throw INVALID_REQUEST.getCustomException(
+          "Invalid RSA key length. Allowed values are [2048, 3072, 4096]");
+    }
+
+    if (!StringUtils.equals(this.format, FORMAT_PEM)
+        && !StringUtils.equals(this.format, FORMAT_JWKS)) {
+      throw INVALID_REQUEST.getCustomException(
+          "Invalid key format. Allowed values are PEM or JWKS");
+    }
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dto/response/RsaKeyResponseDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/response/RsaKeyResponseDto.java
@@ -1,0 +1,24 @@
+package com.dreamsportslabs.guardian.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+import lombok.extern.jackson.Jacksonized;
+
+@Data
+@Builder
+@Jacksonized
+public class RsaKeyResponseDto {
+
+  @JsonProperty("kid")
+  private String kid;
+
+  @JsonProperty("publicKey")
+  private Object publicKey;
+
+  @JsonProperty("privateKey")
+  private Object privateKey;
+
+  @JsonProperty("keySize")
+  private Integer keySize;
+}

--- a/src/main/java/com/dreamsportslabs/guardian/dto/response/RsaKeyResponseDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/response/RsaKeyResponseDto.java
@@ -1,22 +1,15 @@
 package com.dreamsportslabs.guardian.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.extern.jackson.Jacksonized;
 
 @Builder
 @Jacksonized
+@Getter
 public class RsaKeyResponseDto {
-
-  @JsonProperty("kid")
   private String kid;
-
-  @JsonProperty("publicKey")
   private Object publicKey;
-
-  @JsonProperty("privateKey")
   private Object privateKey;
-
-  @JsonProperty("keySize")
   private Integer keySize;
 }

--- a/src/main/java/com/dreamsportslabs/guardian/dto/response/RsaKeyResponseDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/response/RsaKeyResponseDto.java
@@ -2,10 +2,8 @@ package com.dreamsportslabs.guardian.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
-import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
 
-@Data
 @Builder
 @Jacksonized
 public class RsaKeyResponseDto {

--- a/src/main/java/com/dreamsportslabs/guardian/filter/ConfigFilter.java
+++ b/src/main/java/com/dreamsportslabs/guardian/filter/ConfigFilter.java
@@ -32,7 +32,7 @@ public class ConfigFilter implements ContainerRequestFilter {
   public void filter(ContainerRequestContext requestContext) {
     // Todo: create a filter annotation instead of filtering out routes here, @Config
     String path = requestContext.getUriInfo().getPath();
-    if (path.equalsIgnoreCase("/healthcheck")) {
+    if (path.equalsIgnoreCase("/healthcheck") || path.equalsIgnoreCase("/v1/keys/generate")) {
       return;
     }
 

--- a/src/main/java/com/dreamsportslabs/guardian/rest/RsaKeyGeneration.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/RsaKeyGeneration.java
@@ -1,0 +1,46 @@
+package com.dreamsportslabs.guardian.rest;
+
+import static com.dreamsportslabs.guardian.constant.Constants.TENANT_ID;
+
+import com.dreamsportslabs.guardian.dto.request.GenerateRsaKeyRequestDto;
+import com.dreamsportslabs.guardian.dto.response.RsaKeyResponseDto;
+import com.dreamsportslabs.guardian.service.RsaKeyPairGeneratorService;
+import com.google.inject.Inject;
+import io.reactivex.rxjava3.core.Single;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.concurrent.CompletionStage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Path("/v1/keys")
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class RsaKeyGeneration {
+
+  final RsaKeyPairGeneratorService rsaKeyService;
+
+  @POST
+  @Path("/generate")
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public CompletionStage<Response> generateRsaKey(
+      @HeaderParam(TENANT_ID) String tenantId, GenerateRsaKeyRequestDto request) {
+
+    return Single.fromCallable(
+            () -> {
+              RsaKeyResponseDto response = rsaKeyService.generateKey(request);
+              log.info(
+                  "Successfully generated RSA key with kid: {} for tenant: {}",
+                  response.getKid(),
+                  tenantId);
+              return Response.ok(response).build();
+            })
+        .toCompletionStage();
+  }
+}

--- a/src/main/java/com/dreamsportslabs/guardian/rest/RsaKeyGeneration.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/RsaKeyGeneration.java
@@ -1,19 +1,16 @@
 package com.dreamsportslabs.guardian.rest;
 
-import static com.dreamsportslabs.guardian.constant.Constants.TENANT_ID;
-
 import com.dreamsportslabs.guardian.dto.request.GenerateRsaKeyRequestDto;
 import com.dreamsportslabs.guardian.dto.response.RsaKeyResponseDto;
 import com.dreamsportslabs.guardian.service.RsaKeyPairGeneratorService;
 import com.google.inject.Inject;
-import io.reactivex.rxjava3.core.Single;
 import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.HeaderParam;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,18 +26,12 @@ public class RsaKeyGeneration {
   @Path("/generate")
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  public CompletionStage<Response> generateRsaKey(
-      @HeaderParam(TENANT_ID) String tenantId, GenerateRsaKeyRequestDto request) {
+  public CompletionStage<Response> generateRsaKey(GenerateRsaKeyRequestDto request) {
 
-    return Single.fromCallable(
-            () -> {
-              RsaKeyResponseDto response = rsaKeyService.generateKey(request);
-              log.info(
-                  "Successfully generated RSA key with kid: {} for tenant: {}",
-                  response.getKid(),
-                  tenantId);
-              return Response.ok(response).build();
-            })
-        .toCompletionStage();
+    return CompletableFuture.supplyAsync(
+        () -> {
+          RsaKeyResponseDto response = rsaKeyService.generateKey(request);
+          return Response.ok(response).build();
+        });
   }
 }

--- a/src/main/java/com/dreamsportslabs/guardian/rest/RsaKeyGeneration.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/RsaKeyGeneration.java
@@ -27,7 +27,7 @@ public class RsaKeyGeneration {
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
   public CompletionStage<Response> generateRsaKey(GenerateRsaKeyRequestDto request) {
-
+    request.validate();
     return CompletableFuture.supplyAsync(
         () -> {
           RsaKeyResponseDto response = rsaKeyService.generateKey(request);

--- a/src/main/java/com/dreamsportslabs/guardian/service/RsaKeyPairGeneratorService.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/RsaKeyPairGeneratorService.java
@@ -16,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 public class RsaKeyPairGeneratorService {
 
   public RsaKeyResponseDto generateKey(GenerateRsaKeyRequestDto request) {
-    request.validate();
     KeyPair keyPair = getRsaKeyPair(request.getKeySize());
 
     JSONWebKey publicJsonWebKey = JSONWebKey.build(keyPair.publicKey);

--- a/src/main/java/com/dreamsportslabs/guardian/service/RsaKeyPairGeneratorService.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/RsaKeyPairGeneratorService.java
@@ -1,0 +1,60 @@
+package com.dreamsportslabs.guardian.service;
+
+import static com.dreamsportslabs.guardian.constant.Constants.FORMAT_PEM;
+
+import com.dreamsportslabs.guardian.dto.request.GenerateRsaKeyRequestDto;
+import com.dreamsportslabs.guardian.dto.response.RsaKeyResponseDto;
+import com.google.inject.Inject;
+import io.fusionauth.jwks.domain.JSONWebKey;
+import io.fusionauth.jwt.JWTUtils;
+import io.fusionauth.jwt.domain.KeyPair;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor(onConstructor = @__({@Inject}))
+public class RsaKeyPairGeneratorService {
+
+  public RsaKeyResponseDto generateKey(GenerateRsaKeyRequestDto request) {
+    request.validate();
+    KeyPair keyPair = getRsaKeyPair(request.getKeySize());
+
+    JSONWebKey publicJsonWebKey = JSONWebKey.build(keyPair.publicKey);
+    JSONWebKey privateJsonWebKey = JSONWebKey.build(keyPair.privateKey);
+
+    String kid = JWTUtils.generateJWS_kid(privateJsonWebKey);
+
+    if (request.getFormat().equalsIgnoreCase(FORMAT_PEM)) {
+      return RsaKeyResponseDto.builder()
+          .kid(kid)
+          .privateKey(keyPair.privateKey)
+          .publicKey(keyPair.publicKey)
+          .keySize(request.getKeySize())
+          .build();
+    } else {
+      return RsaKeyResponseDto.builder()
+          .kid(kid)
+          .privateKey(privateJsonWebKey)
+          .publicKey(publicJsonWebKey)
+          .keySize(request.getKeySize())
+          .build();
+    }
+  }
+
+  private KeyPair getRsaKeyPair(Integer keySize) {
+    return switch (keySize) {
+      case 4096 -> {
+        log.debug("Generating 4096-bit RSA key pair");
+        yield JWTUtils.generate4096_RSAKeyPair();
+      }
+      case 3072 -> {
+        log.debug("Generating 3072-bit RSA key pair");
+        yield JWTUtils.generate3072_RSAKeyPair();
+      }
+      default -> {
+        log.debug("Generating 2048-bit RSA key pair");
+        yield JWTUtils.generate2048_RSAKeyPair();
+      }
+    };
+  }
+}

--- a/src/test/java/com/dreamsportslabs/guardian/Constants.java
+++ b/src/test/java/com/dreamsportslabs/guardian/Constants.java
@@ -102,4 +102,47 @@ public class Constants {
   public static final String PASSWORDLESS_MODEL_CONTACTS = "contacts";
   public static final String PASSWORDLESS_MODEL_CONTACTS_TEMPLATE = "template";
   public static final String PASSWORDLESS_MODEL_CONTACTS_TEMPLATE_NAME = "name";
+
+  // RSA Key Generation
+  public static final String TENANT_VALID = "tenant1";
+  public static final String RSA_KEY_KID = "kid";
+  public static final String RSA_KEY_PUBLIC_KEY = "publicKey";
+  public static final String RSA_KEY_PRIVATE_KEY = "privateKey";
+  public static final String RSA_KEY_SIZE = "keySize";
+  public static final String RSA_KEY_FORMAT = "format";
+  public static final String RSA_KEY_TYPE = "kty";
+  public static final String RSA_KEY_USE = "use";
+  public static final String RSA_KEY_MODULUS = "n";
+  public static final String RSA_KEY_EXPONENT = "e";
+  public static final int RSA_KEY_SIZE_2048 = 2048;
+  public static final int RSA_KEY_SIZE_3072 = 3072;
+  public static final int RSA_KEY_SIZE_4096 = 4096;
+  public static final int RSA_KEY_SIZE_INVALID = 1024;
+  public static final int RSA_PUBLIC_EXPONENT = 65537;
+  public static final int RSA_4096_MIN_LENGTH = 3000;
+  public static final int RSA_KID_MIN_LENGTH = 10;
+  public static final String RSA_FORMAT_PEM = "PEM";
+  public static final String RSA_FORMAT_JWKS = "JWKS";
+  public static final String RSA_FORMAT_INVALID = "INVALID";
+  public static final String RSA_FORMAT_EMPTY = "";
+  public static final String RSA_KEY_TYPE_RSA = "RSA";
+  public static final String RSA_KEY_USE_SIG = "sig";
+  public static final String RSA_KEY_EXPONENT_AQAB = "AQAB";
+  public static final String RSA_ALGORITHM = "RSA";
+  public static final String PEM_PUBLIC_KEY_HEADER = "-----BEGIN PUBLIC KEY-----";
+  public static final String PEM_PUBLIC_KEY_FOOTER = "-----END PUBLIC KEY-----";
+  public static final String PEM_PRIVATE_KEY_HEADER = "-----BEGIN PRIVATE KEY-----";
+  public static final String PEM_PRIVATE_KEY_FOOTER = "-----END PRIVATE KEY-----";
+  public static final String ERROR_MSG_INVALID_RSA_KEY_LENGTH =
+      "Invalid RSA key length. Allowed values are [2048, 3072, 4096]";
+  public static final String ERROR_MSG_INVALID_KEY_FORMAT =
+      "Invalid key format. Allowed values are PEM or JWKS";
+
+  public static final String ASSERT_PUBLIC_KEY_MODULUS_2048 =
+      "Public key modulus should be 2048 bits";
+  public static final String ASSERT_PRIVATE_KEY_MODULUS_2048 =
+      "Private key modulus should be 2048 bits";
+  public static final String ASSERT_KEYS_SAME_MODULUS =
+      "Public and private keys should have same modulus";
+  public static final String ASSERT_PUBLIC_EXPONENT_65537 = "Public exponent should be 65537";
 }

--- a/src/test/java/com/dreamsportslabs/guardian/it/RsaKeyGenerationIT.java
+++ b/src/test/java/com/dreamsportslabs/guardian/it/RsaKeyGenerationIT.java
@@ -1,0 +1,303 @@
+package com.dreamsportslabs.guardian.it;
+
+import static com.dreamsportslabs.guardian.utils.ApplicationIoUtils.generateRsaKey;
+import static org.apache.commons.lang3.RandomStringUtils.randomAlphanumeric;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import io.restassured.response.Response;
+import io.vertx.core.json.JsonObject;
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@Slf4j
+public class RsaKeyGenerationIT {
+
+  private static final String TENANT_VALID = "tenant1";
+  private static final String TENANT_UNKNOWN = randomAlphanumeric(8);
+
+  private JsonObject extractResponseBody(Response response) {
+    return new JsonObject(response.getBody().asString());
+  }
+
+  @Test
+  @DisplayName("Should generate RSA key with defaults successfully")
+  void generateRsaKeyWithDefaults() throws Exception {
+    // Arrange
+    Map<String, Object> requestBody = new HashMap<>();
+
+    // Act
+    Response response = generateRsaKey(TENANT_VALID, requestBody);
+
+    // Assert
+    assertThat(response.getStatusCode(), equalTo(200));
+
+    JsonObject responseBody = extractResponseBody(response);
+
+    // Verify response structure
+    assertThat(responseBody.getString("kid"), notNullValue());
+    assertThat(responseBody.getValue("publicKey"), notNullValue());
+    assertThat(responseBody.getValue("privateKey"), notNullValue());
+    assertThat(responseBody.getInteger("keySize"), equalTo(2048));
+
+    // Verify PEM format (default)
+    String publicKey = responseBody.getString("publicKey");
+    String privateKey = responseBody.getString("privateKey");
+    String kid = responseBody.getString("kid");
+
+    assertThat(publicKey, containsString("-----BEGIN PUBLIC KEY-----"));
+    assertThat(publicKey, containsString("-----END PUBLIC KEY-----"));
+    assertThat(privateKey, containsString("-----BEGIN PRIVATE KEY-----"));
+    assertThat(privateKey, containsString("-----END PRIVATE KEY-----"));
+
+    // Verify keys can be parsed as valid RSA keys
+    RSAPublicKey publicKeyObj = parsePublicKey(publicKey);
+    RSAPrivateKey privateKeyObj = parsePrivateKey(privateKey);
+
+    // Verify key properties
+    assertThat(
+        "Public key modulus should be 2048 bits",
+        publicKeyObj.getModulus().bitLength(),
+        equalTo(2048));
+    assertThat(
+        "Private key modulus should be 2048 bits",
+        privateKeyObj.getModulus().bitLength(),
+        equalTo(2048));
+
+    // Verify public and private keys are mathematically related
+    assertThat(
+        "Public and private keys should have same modulus",
+        publicKeyObj.getModulus(),
+        equalTo(privateKeyObj.getModulus()));
+
+    // Verify public exponent is standard (65537)
+    assertThat(
+        "Public exponent should be 65537",
+        publicKeyObj.getPublicExponent().intValue(),
+        equalTo(65537));
+
+    assertThat(kid, notNullValue());
+    assertThat(kid.length(), greaterThan(0));
+
+    // Should be a reasonable length for a key identifier
+    assertThat(kid.length(), greaterThan(10));
+  }
+
+  @Test
+  @DisplayName("Should generate RSA key with 4096-bit key size")
+  void generateRsaKeyWith4096BitSize() {
+    // Arrange
+    Map<String, Object> requestBody = new HashMap<>();
+    requestBody.put("keySize", 4096);
+    requestBody.put("format", "PEM");
+
+    // Act
+    Response response = generateRsaKey(TENANT_VALID, requestBody);
+
+    // Assert
+    assertThat(response.getStatusCode(), equalTo(200));
+
+    JsonObject responseBody = extractResponseBody(response);
+    assertThat(responseBody.getInteger("keySize"), equalTo(4096));
+
+    // 4096-bit keys should be longer than 2048-bit keys
+    String privateKey = responseBody.getString("privateKey");
+    assertThat(privateKey.length(), greaterThan(3000));
+  }
+
+  @Test
+  @DisplayName("Should generate RSA key with 3072-bit key size")
+  void generateRsaKeyWith3072BitSize() {
+    // Arrange
+    Map<String, Object> requestBody = new HashMap<>();
+    requestBody.put("keySize", 3072);
+    requestBody.put("format", "PEM");
+
+    // Act
+    Response response = generateRsaKey(TENANT_VALID, requestBody);
+
+    // Assert
+    assertThat(response.getStatusCode(), equalTo(200));
+
+    JsonObject responseBody = extractResponseBody(response);
+    assertThat(responseBody.getInteger("keySize"), equalTo(3072));
+  }
+
+  @Test
+  @DisplayName("Should generate RSA key in JWKS format")
+  void generateRsaKeyInJwksFormat() {
+    // Arrange
+    Map<String, Object> requestBody = new HashMap<>();
+    requestBody.put("format", "JWKS");
+
+    // Act
+    Response response = generateRsaKey(TENANT_VALID, requestBody);
+
+    // Assert
+    assertThat(response.getStatusCode(), equalTo(200));
+
+    JsonObject responseBody = extractResponseBody(response);
+
+    // In JWKS format, keys should be JSON objects, not strings
+    assertThat(responseBody.getValue("publicKey"), instanceOf(JsonObject.class));
+    assertThat(responseBody.getValue("privateKey"), instanceOf(JsonObject.class));
+
+    // Verify JWKS structure for public key
+    JsonObject publicKey = responseBody.getJsonObject("publicKey");
+    assertThat(publicKey.getString("kty"), equalTo("RSA"));
+    assertThat(publicKey.getString("use"), equalTo("sig"));
+    assertThat(publicKey.getString("n"), notNullValue());
+    assertThat(publicKey.getString("e"), equalTo("AQAB"));
+  }
+
+  @Test
+  @DisplayName("Should generate different keys on multiple calls")
+  void generateMultipleRsaKeysAreDifferent() {
+    // Arrange
+    Map<String, Object> requestBody = new HashMap<>();
+
+    // Act
+    Response response1 = generateRsaKey(TENANT_VALID, requestBody);
+    Response response2 = generateRsaKey(TENANT_VALID, requestBody);
+
+    // Assert
+    assertThat(response1.getStatusCode(), equalTo(200));
+    assertThat(response2.getStatusCode(), equalTo(200));
+
+    JsonObject responseBody1 = extractResponseBody(response1);
+    JsonObject responseBody2 = extractResponseBody(response2);
+
+    // Keys should be different
+    assertThat(responseBody1.getString("kid"), is(not(equalTo(responseBody2.getString("kid")))));
+    assertThat(
+        responseBody1.getString("publicKey"),
+        is(not(equalTo(responseBody2.getString("publicKey")))));
+    assertThat(
+        responseBody1.getString("privateKey"),
+        is(not(equalTo(responseBody2.getString("privateKey")))));
+  }
+
+  @Test
+  @DisplayName("Should return error for invalid key size")
+  void generateRsaKeyWithInvalidKeySize() {
+    // Arrange
+    Map<String, Object> requestBody = new HashMap<>();
+    requestBody.put("keySize", 1024); // Invalid key size
+
+    // Act
+    Response response = generateRsaKey(TENANT_VALID, requestBody);
+
+    // Assert
+    assertThat(response.getStatusCode(), equalTo(400));
+    assertThat(response.getBody().jsonPath().getString("error.code"), equalTo("invalid_request"));
+    assertThat(
+        response.getBody().jsonPath().getString("error.message"),
+        equalTo("Invalid RSA key length. Allowed values are [2048, 3072, 4096]"));
+  }
+
+  @Test
+  @DisplayName("Should return error for invalid format")
+  void generateRsaKeyWithInvalidFormat() {
+    // Arrange
+    Map<String, Object> requestBody = new HashMap<>();
+    requestBody.put("format", "INVALID"); // Invalid format
+
+    // Act
+    Response response = generateRsaKey(TENANT_VALID, requestBody);
+
+    // Assert
+    assertThat(response.getStatusCode(), equalTo(400));
+
+    assertThat(response.getBody().jsonPath().getString("error.code"), equalTo("invalid_request"));
+    assertThat(
+        response.getBody().jsonPath().getString("error.message"),
+        equalTo("Invalid key format. Allowed values are PEM or JWKS"));
+  }
+
+  @Test
+  @DisplayName("Should return error for missing format")
+  void generateRsaKeyWithMissingFormat() {
+    // Arrange
+    Map<String, Object> requestBody = new HashMap<>();
+    requestBody.put("format", ""); // Empty format
+
+    // Act
+    Response response = generateRsaKey(TENANT_VALID, requestBody);
+
+    // Assert
+    assertThat(response.getStatusCode(), equalTo(400));
+
+    assertThat(response.getBody().jsonPath().getString("error.code"), equalTo("invalid_request"));
+    assertThat(
+        response.getBody().jsonPath().getString("error.message"),
+        equalTo("Invalid key format. Allowed values are PEM or JWKS"));
+  }
+
+  @Test
+  @DisplayName("Should return error for unknown tenant")
+  void generateRsaKeyWithUnknownTenant() {
+    // Arrange
+    Map<String, Object> requestBody = new HashMap<>();
+
+    // Act
+    Response response = generateRsaKey(TENANT_UNKNOWN, requestBody);
+
+    // Assert
+    assertThat(response.getStatusCode(), equalTo(400));
+  }
+
+  @Test
+  @DisplayName("Should return error when tenant header is missing")
+  void generateRsaKeyWithoutTenantHeader() {
+    // Arrange
+    Map<String, Object> requestBody = new HashMap<>();
+
+    // Act
+    Response response = generateRsaKey(null, requestBody);
+
+    // Assert
+    assertThat(response.getStatusCode(), equalTo(401));
+  }
+
+  // Helper methods for key parsing
+  private RSAPublicKey parsePublicKey(String publicKeyPem) throws Exception {
+    String publicKeyContent =
+        publicKeyPem
+            .replace("-----BEGIN PUBLIC KEY-----", "")
+            .replace("-----END PUBLIC KEY-----", "")
+            .replaceAll("\\s", "");
+
+    byte[] keyBytes = Base64.getDecoder().decode(publicKeyContent);
+    X509EncodedKeySpec spec = new X509EncodedKeySpec(keyBytes);
+    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+    return (RSAPublicKey) keyFactory.generatePublic(spec);
+  }
+
+  private RSAPrivateKey parsePrivateKey(String privateKeyPem) throws Exception {
+    String privateKeyContent =
+        privateKeyPem
+            .replace("-----BEGIN PRIVATE KEY-----", "")
+            .replace("-----END PRIVATE KEY-----", "")
+            .replaceAll("\\s", "");
+
+    byte[] keyBytes = Base64.getDecoder().decode(privateKeyContent);
+    PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyBytes);
+    KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+    return (RSAPrivateKey) keyFactory.generatePrivate(spec);
+  }
+}

--- a/src/test/java/com/dreamsportslabs/guardian/utils/ApplicationIoUtils.java
+++ b/src/test/java/com/dreamsportslabs/guardian/utils/ApplicationIoUtils.java
@@ -122,4 +122,14 @@ public class ApplicationIoUtils {
 
     return execute(null, headers, new HashMap<>(), spec -> spec.get("/v1/certs"));
   }
+
+  public static Response generateRsaKey(String tenantId, Map<String, Object> body) {
+    Map<String, String> headers = new HashMap<>();
+    if (tenantId != null) {
+      headers.put(HEADER_TENANT_ID, tenantId);
+    }
+    headers.put(CONTENT_TYPE, "application/json");
+
+    return execute(body, headers, new HashMap<>(), spec -> spec.post("/v1/keys/generate"));
+  }
 }

--- a/src/test/java/com/dreamsportslabs/guardian/utils/ApplicationIoUtils.java
+++ b/src/test/java/com/dreamsportslabs/guardian/utils/ApplicationIoUtils.java
@@ -123,11 +123,8 @@ public class ApplicationIoUtils {
     return execute(null, headers, new HashMap<>(), spec -> spec.get("/v1/certs"));
   }
 
-  public static Response generateRsaKey(String tenantId, Map<String, Object> body) {
+  public static Response generateRsaKey(Map<String, Object> body) {
     Map<String, String> headers = new HashMap<>();
-    if (tenantId != null) {
-      headers.put(HEADER_TENANT_ID, tenantId);
-    }
     headers.put(CONTENT_TYPE, "application/json");
 
     return execute(body, headers, new HashMap<>(), spec -> spec.post("/v1/keys/generate"));


### PR DESCRIPTION
# Add RSA Key Generation API

## 📋 Summary

This PR introduces a new REST API endpoint for generating RSA key pairs with support for multiple key sizes and output formats. 

## 🚀 Features Added

### **New API Endpoint**
• **POST** /v1/keys/generate - Generate RSA key pairs with configurable parameters

### **Key Generation Capabilities**
• **Multiple Key Sizes**: Support for 2048, 3072, and 4096-bit RSA keys
• **Dual Output Formats**: 
  • **PEM**: Traditional PEM-encoded keys for standard cryptographic operations
  • **JWKS**: JSON Web Key Set format for JWT/OAuth2 workflows
• **Unique Key Identifiers**: Auto-generated kid (Key ID) for key management
• **Secure Generation**: Uses FusionAuth JWT utilities for cryptographically secure key generation

### **Request/Response Structure**
json
// Request
{
  "keySize": 2048,     // Optional: 2048 (default), 3072, or 4096
  "format": "PEM"      // Optional: "PEM" (default) or "JWKS"
}

// Response
{
  "kid": "generated-key-id",
  "publicKey": "-----BEGIN PUBLIC KEY-----...",
  "privateKey": "-----BEGIN PRIVATE KEY-----...",
  "keySize": 2048
}


## 🔍 API Usage Example

bash
# Generate default 2048-bit PEM keys
```
curl -X POST "http://localhost:8080/v1/keys/generate" \
  -H "tenant-id: tenant1" \
  -H "Content-Type: application/json" \
  -d '{}'
```

# Generate 4096-bit JWKS format keys
```
curl -X POST "http://localhost:8080/v1/keys/generate" \
  -H "tenant-id: tenant1" \
  -H "Content-Type: application/json" \
  -d '{"keySize": 4096, "format": "JWKS"}'
```
