### PR TITLE
feat: add tid claim in access token

### DIFF
--- a/src/main/java/com/dreamsportslabs/guardian/constant/Constants.java
+++ b/src/main/java/com/dreamsportslabs/guardian/constant/Constants.java
@@ -57,6 +57,7 @@ public final class Constants {
   public static final String JWT_CLAIMS_EXP = "exp";
   public static final String JWT_CLAIMS_RFT_ID = "rft_id";
   public static final String JWT_CLAIMS_AUD = "aud";
+  public static final String JWT_TENANT_ID_CLAIM = "tid";
 
   public static final ImmutableList<String> fbAuthResponseTypes = ImmutableList.of(CODE, TOKEN);
   public static final ImmutableList<String> passwordlessAuthResponseTypes =

--- a/src/main/java/com/dreamsportslabs/guardian/service/TokenIssuer.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/TokenIssuer.java
@@ -5,6 +5,7 @@ import static com.dreamsportslabs.guardian.constant.Constants.JWT_CLAIMS_IAT;
 import static com.dreamsportslabs.guardian.constant.Constants.JWT_CLAIMS_ISS;
 import static com.dreamsportslabs.guardian.constant.Constants.JWT_CLAIMS_RFT_ID;
 import static com.dreamsportslabs.guardian.constant.Constants.JWT_CLAIMS_SUB;
+import static com.dreamsportslabs.guardian.constant.Constants.JWT_TENANT_ID_CLAIM;
 import static com.dreamsportslabs.guardian.constant.Constants.USERID;
 import static com.dreamsportslabs.guardian.exception.ErrorEnum.INTERNAL_SERVER_ERROR;
 
@@ -57,7 +58,8 @@ public class TokenIssuer {
                 iat,
                 iat + config.getTokenConfig().getAccessTokenExpiry(),
                 config.getTokenConfig().getIssuer())
-            .addClaim(JWT_CLAIMS_RFT_ID, rftId);
+            .addClaim(JWT_CLAIMS_RFT_ID, rftId)
+            .addClaim(JWT_TENANT_ID_CLAIM, config.getTenantId());
 
     return signToken(jwt, config.getTenantId());
   }

--- a/src/test/java/com/dreamsportslabs/guardian/Constants.java
+++ b/src/test/java/com/dreamsportslabs/guardian/Constants.java
@@ -69,6 +69,7 @@ public class Constants {
   public static final String JWT_CLAIM_ISS = "iss";
   public static final String JWT_CLAIM_SUB = "sub";
   public static final String JWT_CLAIM_RFT_ID = "rft_id";
+  public static final String JWT_CLAIM_TENANT_ID = "tid";
 
   // Error Response
   public static final String ERROR = "error";

--- a/src/test/java/com/dreamsportslabs/guardian/it/RefreshTokenIT.java
+++ b/src/test/java/com/dreamsportslabs/guardian/it/RefreshTokenIT.java
@@ -5,6 +5,7 @@ import static com.dreamsportslabs.guardian.Constants.JWT_CLAIM_IAT;
 import static com.dreamsportslabs.guardian.Constants.JWT_CLAIM_ISS;
 import static com.dreamsportslabs.guardian.Constants.JWT_CLAIM_RFT_ID;
 import static com.dreamsportslabs.guardian.Constants.JWT_CLAIM_SUB;
+import static com.dreamsportslabs.guardian.Constants.JWT_CLAIM_TENANT_ID;
 import static com.dreamsportslabs.guardian.Constants.JWT_HEADER_KID;
 import static com.dreamsportslabs.guardian.constant.Constants.ACCESS_TOKEN_COOKIE_NAME;
 import static com.dreamsportslabs.guardian.constant.Constants.REFRESH_TOKEN_COOKIE_NAME;
@@ -55,6 +56,7 @@ public class RefreshTokenIT {
     assertThat(jwt.getHeaderClaim(JWT_HEADER_KID), equalTo("test-kid"));
     assertThat(claims.get(JWT_CLAIM_SUB), equalTo(userId));
     assertThat(claims.get(JWT_CLAIM_ISS), equalTo("https://test.com"));
+    assertThat(claims.get(JWT_CLAIM_TENANT_ID), equalTo(tenant1));
 
     long exp = ((ZonedDateTime) claims.get(JWT_CLAIM_EXP)).toInstant().toEpochMilli() / 1000;
     long iat = ((ZonedDateTime) claims.get(JWT_CLAIM_IAT)).toInstant().toEpochMilli() / 1000;


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR adds tenant ID functionality to access tokens by introducing a 'tid' claim in the token generation process. The implementation includes updates to constants, token issuer logic, and corresponding test files. These changes enhance multi-tenancy support by ensuring tokens carry tenant identification data.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>