### PR TITLE
fix: add retryAfter field in error response when a flow is blocked

### DIFF
--- a/src/main/java/com/dreamsportslabs/guardian/dao/UserFlowBlockDao.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/UserFlowBlockDao.java
@@ -72,7 +72,7 @@ public class UserFlowBlockDao {
         .map(rowSet -> JsonUtils.rowSetToList(rowSet, String.class));
   }
 
-  public Single<List<String>> checkFlowBlockedWithReasonBatch(
+  public Single<List<UserFlowBlockModel>> checkFlowBlockedWithReasonBatch(
       String tenantId, List<String> userIdentifiers, BlockFlow flowName) {
 
     String placeholders = String.join(",", userIdentifiers.stream().map(c -> "?").toList());
@@ -87,6 +87,6 @@ public class UserFlowBlockDao {
         .getReaderPool()
         .preparedQuery(query)
         .rxExecute(params)
-        .map(rowSet -> JsonUtils.rowSetToList(rowSet, String.class));
+        .map(rowSet -> JsonUtils.rowSetToList(rowSet, UserFlowBlockModel.class));
   }
 }

--- a/src/main/java/com/dreamsportslabs/guardian/dao/query/UserFlowBlockSql.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/query/UserFlowBlockSql.java
@@ -19,5 +19,5 @@ public class UserFlowBlockSql {
       "SELECT flow_name FROM user_flow_block WHERE tenant_id = ? AND user_identifier = ? AND is_active = 1 AND (unblocked_at > UNIX_TIMESTAMP())";
 
   public static final String GET_FLOW_BLOCK_REASON_BATCH =
-      "SELECT reason FROM user_flow_block WHERE tenant_id = ? AND flow_name = ? AND user_identifier IN (%s) AND is_active = 1 AND (unblocked_at > UNIX_TIMESTAMP())";
+      "SELECT reason, unblocked_at FROM user_flow_block WHERE tenant_id = ? AND flow_name = ? AND user_identifier IN (%s) AND is_active = 1 AND (unblocked_at > UNIX_TIMESTAMP())";
 }

--- a/src/test/java/com/dreamsportslabs/guardian/it/userBlockFlow/UserBlockFlowsIT.java
+++ b/src/test/java/com/dreamsportslabs/guardian/it/userBlockFlow/UserBlockFlowsIT.java
@@ -398,7 +398,8 @@ public class UserBlockFlowsIT {
         .statusCode(HttpStatus.SC_FORBIDDEN)
         .rootPath(ERROR)
         .body(CODE, equalTo(ERROR_FLOW_BLOCKED))
-        .body(MESSAGE, equalTo(reason));
+        .body(MESSAGE, equalTo(reason))
+        .body("metadata.retryAfter.toString()", equalTo(String.valueOf(UNBLOCKED_AT)));
 
     wireMockServer.removeStub(userStub);
     wireMockServer.removeStub(emailStub);
@@ -429,7 +430,8 @@ public class UserBlockFlowsIT {
         .statusCode(HttpStatus.SC_FORBIDDEN)
         .rootPath(ERROR)
         .body(CODE, equalTo(ERROR_FLOW_BLOCKED))
-        .body(MESSAGE, equalTo(reason));
+        .body(MESSAGE, equalTo(reason))
+        .body("metadata.retryAfter.toString()", equalTo(String.valueOf(UNBLOCKED_AT)));
   }
 
   @Test
@@ -460,7 +462,8 @@ public class UserBlockFlowsIT {
           .statusCode(HttpStatus.SC_FORBIDDEN)
           .rootPath(ERROR)
           .body(CODE, equalTo(ERROR_FLOW_BLOCKED))
-          .body(MESSAGE, equalTo(reason));
+          .body(MESSAGE, equalTo(reason))
+          .body("metadata.retryAfter.toString()", equalTo(String.valueOf(UNBLOCKED_AT)));
     }
   }
 
@@ -487,7 +490,8 @@ public class UserBlockFlowsIT {
         .statusCode(HttpStatus.SC_FORBIDDEN)
         .rootPath(ERROR)
         .body(CODE, equalTo(ERROR_FLOW_BLOCKED))
-        .body(MESSAGE, equalTo(reason));
+        .body(MESSAGE, equalTo(reason))
+        .body("metadata.retryAfter.toString()", equalTo(String.valueOf(UNBLOCKED_AT)));
   }
 
   @Test
@@ -513,7 +517,8 @@ public class UserBlockFlowsIT {
         .statusCode(HttpStatus.SC_FORBIDDEN)
         .rootPath(ERROR)
         .body(CODE, equalTo(ERROR_FLOW_BLOCKED))
-        .body(MESSAGE, equalTo(reason));
+        .body(MESSAGE, equalTo(reason))
+        .body("metadata.retryAfter.toString()", equalTo(String.valueOf(UNBLOCKED_AT)));
   }
 
   @Test


### PR DESCRIPTION
<h3>Description</h3>

The user flow block response, returned when an API call fails because the user is blocked for that flow, was modified to include a `retryAfter` epoch field in the error response. This allows users to know precisely when they can retry the request.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- [x] Written test cases across various scenarios and tested locally

## API Curls

**contact/block** 
`curl -X POST "http://localhost:8080/v1/user/flow/block" \
  -H "Content-Type: application/json" \
  -H "tenant-id: tenant1" \
  -d '{
    "userIdentifier": "user@example.com",
    "blockFlows": ["passwordless", "social_auth"],
    "reason": "Suspicious activity detected",
    "unblockedAt": 1704067200
  }'`