### PR TITLE
feat: add validation to preserve TTL when updating existing key

### DIFF
--- a/src/main/java/com/dreamsportslabs/guardian/dao/PasswordlessDao.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/PasswordlessDao.java
@@ -1,7 +1,7 @@
 package com.dreamsportslabs.guardian.dao;
 
 import static com.dreamsportslabs.guardian.constant.Constants.CACHE_KEY_STATE;
-import static com.dreamsportslabs.guardian.constant.Constants.EXPIRY_OPTION_REDIS;
+import static com.dreamsportslabs.guardian.constant.Constants.EXPIRE_AT_REDIS;
 import static com.dreamsportslabs.guardian.exception.ErrorEnum.INTERNAL_SERVER_ERROR;
 
 import com.dreamsportslabs.guardian.dao.model.PasswordlessModel;
@@ -35,9 +35,8 @@ public class PasswordlessDao {
             Request.cmd(Command.SET)
                 .arg(getCacheKey(tenantId, model.getState()))
                 .arg(objectMapper.writeValueAsString(model))
-                .arg(EXPIRY_OPTION_REDIS)
-                // Todo: arbitrary expiry to eventually expire, > allowed max otp validity
-                .arg(3600))
+                .arg(EXPIRE_AT_REDIS)
+                .arg(model.getExpiry()))
         .onErrorResumeNext(err -> Maybe.error(INTERNAL_SERVER_ERROR.getException(err)))
         .map(response -> model)
         .toSingle();

--- a/src/test/java/com/dreamsportslabs/guardian/utils/DbUtils.java
+++ b/src/test/java/com/dreamsportslabs/guardian/utils/DbUtils.java
@@ -252,4 +252,15 @@ public class DbUtils {
     List<String> revocations = getRevocationsFromRedis(tenantId);
     return revocations.contains(rftId);
   }
+
+  public static long getStateTtl(String state, String tenantId) {
+    String key = "STATE" + "_" + tenantId + "_" + state;
+
+    try (Jedis jedis = redisConnectionPool.getResource()) {
+      return jedis.ttl(key);
+    } catch (Exception e) {
+      log.error("Error getting TTL for Redis key: {}", key, e);
+      throw new RuntimeException("Error getting TTL for Redis key: " + key, e);
+    }
+  }
 }


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances TTL management in the passwordless authentication system by introducing new Redis constants and updating the PasswordlessDao to maintain TTL for existing keys. It also includes unit tests to verify the functionality of these changes.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: True
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-documented, making the review process relatively quick.
-->
</div>