### PR TITLE
Converted payload and response keys to snakecase in oidc

### DIFF
--- a/src/main/java/com/dreamsportslabs/guardian/dto/request/ConsentAcceptRequestDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/request/ConsentAcceptRequestDto.java
@@ -1,6 +1,7 @@
 package com.dreamsportslabs.guardian.dto.request;
 
 import com.dreamsportslabs.guardian.exception.OidcErrorEnum;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -13,8 +14,14 @@ import org.apache.commons.lang3.StringUtils;
 @Setter
 @RequiredArgsConstructor
 public class ConsentAcceptRequestDto {
+
+  @JsonProperty("consent_challenge")
   private String consentChallenge;
+
+  @JsonProperty("consented_scopes")
   private List<String> consentedScopes;
+
+  @JsonProperty("refresh_token")
   private String refreshToken;
 
   public void setConsentedScopes(List<String> consentedScopes) {

--- a/src/main/java/com/dreamsportslabs/guardian/dto/request/LoginAcceptRequestDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/request/LoginAcceptRequestDto.java
@@ -2,12 +2,17 @@ package com.dreamsportslabs.guardian.dto.request;
 
 import static com.dreamsportslabs.guardian.exception.OidcErrorEnum.INVALID_REQUEST;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 
 @Data
 public class LoginAcceptRequestDto {
+
+  @JsonProperty("login_challenge")
   private String loginChallenge;
+
+  @JsonProperty("refresh_token")
   private String refreshToken;
 
   public void validate() {

--- a/src/main/java/com/dreamsportslabs/guardian/dto/request/scope/CreateScopeRequestDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/request/scope/CreateScopeRequestDto.java
@@ -3,6 +3,7 @@ package com.dreamsportslabs.guardian.dto.request.scope;
 import static com.dreamsportslabs.guardian.exception.ErrorEnum.INVALID_REQUEST;
 import static com.dreamsportslabs.guardian.utils.ScopeUtil.validateClaims;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
@@ -10,11 +11,23 @@ import org.apache.commons.lang3.StringUtils;
 
 @Data
 public class CreateScopeRequestDto {
+
+  @JsonProperty("name")
   private String name;
+
+  @JsonProperty("display_name")
   private String displayName;
+
+  @JsonProperty("description")
   private String description;
+
+  @JsonProperty("claims")
   private List<String> claims = new ArrayList<>();
+
+  @JsonProperty("icon_url")
   private String iconUrl;
+
+  @JsonProperty("is_oidc")
   private Boolean isOidc = Boolean.FALSE;
 
   public void validate() {

--- a/src/main/java/com/dreamsportslabs/guardian/dto/request/scope/CreateScopeRequestDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/request/scope/CreateScopeRequestDto.java
@@ -12,16 +12,13 @@ import org.apache.commons.lang3.StringUtils;
 @Data
 public class CreateScopeRequestDto {
 
-  @JsonProperty("name")
   private String name;
 
   @JsonProperty("display_name")
   private String displayName;
 
-  @JsonProperty("description")
   private String description;
 
-  @JsonProperty("claims")
   private List<String> claims = new ArrayList<>();
 
   @JsonProperty("icon_url")

--- a/src/main/java/com/dreamsportslabs/guardian/dto/request/scope/GetScopeRequestDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/request/scope/GetScopeRequestDto.java
@@ -17,7 +17,7 @@ public class GetScopeRequestDto {
   @DefaultValue("1")
   private int page;
 
-  @QueryParam("pageSize")
+  @QueryParam("page_size")
   @DefaultValue("10")
   private int pageSize;
 

--- a/src/main/java/com/dreamsportslabs/guardian/dto/request/scope/UpdateScopeRequestDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/request/scope/UpdateScopeRequestDto.java
@@ -3,16 +3,25 @@ package com.dreamsportslabs.guardian.dto.request.scope;
 import static com.dreamsportslabs.guardian.exception.ErrorEnum.INVALID_REQUEST;
 import static com.dreamsportslabs.guardian.utils.ScopeUtil.validateClaims;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
 
 @Data
 public class UpdateScopeRequestDto {
+
+  @JsonProperty("display_name")
   private String displayName;
+
   private String description;
+
   private List<String> claims;
+
+  @JsonProperty("icon_url")
   private String iconUrl;
+
+  @JsonProperty("is_oidc")
   private Boolean isOidc;
 
   public void validate(String scopeName) {

--- a/src/main/java/com/dreamsportslabs/guardian/dto/response/AuthCodeResponseDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/response/AuthCodeResponseDto.java
@@ -1,5 +1,6 @@
 package com.dreamsportslabs.guardian.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import lombok.AllArgsConstructor;
@@ -8,7 +9,10 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class AuthCodeResponseDto {
+
+  @JsonProperty("redirect_uri")
   private String redirectUri;
+
   private String state;
   private String code;
 

--- a/src/main/java/com/dreamsportslabs/guardian/dto/response/AuthCodeResponseDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/response/AuthCodeResponseDto.java
@@ -1,6 +1,5 @@
 package com.dreamsportslabs.guardian.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import lombok.AllArgsConstructor;
@@ -9,10 +8,7 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class AuthCodeResponseDto {
-
-  @JsonProperty("redirect_uri")
   private String redirectUri;
-
   private String state;
   private String code;
 

--- a/src/main/java/com/dreamsportslabs/guardian/dto/response/LoginAcceptResponseDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/response/LoginAcceptResponseDto.java
@@ -3,6 +3,7 @@ package com.dreamsportslabs.guardian.dto.response;
 import static com.dreamsportslabs.guardian.constant.Constants.OIDC_PARAM_CONSENT_CHALLENGE;
 import static com.dreamsportslabs.guardian.constant.Constants.OIDC_PARAM_STATE;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriBuilder;
 import lombok.AllArgsConstructor;
@@ -11,8 +12,13 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class LoginAcceptResponseDto {
+
+  @JsonProperty("consent_page_uri")
   private String consentPageUri;
+
+  @JsonProperty("consent_challenge")
   private String consentChallenge;
+
   private String state;
 
   public Response toResponse() {

--- a/src/main/java/com/dreamsportslabs/guardian/dto/response/LoginAcceptResponseDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/response/LoginAcceptResponseDto.java
@@ -13,7 +13,6 @@ import lombok.Data;
 @AllArgsConstructor
 public class LoginAcceptResponseDto {
 
-  @JsonProperty("consent_page_uri")
   private String consentPageUri;
 
   @JsonProperty("consent_challenge")

--- a/src/main/java/com/dreamsportslabs/guardian/dto/response/ScopeResponseDto.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dto/response/ScopeResponseDto.java
@@ -1,5 +1,6 @@
 package com.dreamsportslabs.guardian.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,9 +11,17 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ScopeResponseDto {
   private String name;
+
+  @JsonProperty("display_name")
   private String displayName;
+
   private String description;
+
+  @JsonProperty("icon_url")
   private String iconUrl;
+
+  @JsonProperty("is_oidc")
   private Boolean isOidc;
+
   private List<String> claims;
 }

--- a/src/test/java/com/dreamsportslabs/guardian/Constants.java
+++ b/src/test/java/com/dreamsportslabs/guardian/Constants.java
@@ -140,7 +140,7 @@ public class Constants {
       "pageSize must be between 1 and 100";
 
   public static final String QUERY_PARAM_PAGE = "page";
-  public static final String QUERY_PARAM_PAGE_SIZE = "pageSize";
+  public static final String QUERY_PARAM_PAGE_SIZE = "page_size";
   public static final String QUERY_PARAM_NAME = "name";
 
   public static final String PASSWORDLESS_FLOW_SIGNINUP = "SIGNINUP";

--- a/src/test/java/com/dreamsportslabs/guardian/Constants.java
+++ b/src/test/java/com/dreamsportslabs/guardian/Constants.java
@@ -7,6 +7,7 @@ public class Constants {
   // Request Body Params
   public static final String BODY_PARAM_USERNAME = "username";
   public static final String BODY_PARAM_PASSWORD = "password";
+  public static final String OIDC_BODY_PARAM_REFRESH_TOKEN = "refresh_token";
   public static final String BODY_PARAM_REFRESH_TOKEN = "refreshToken";
   public static final String BODY_PARAM_RESPONSE_TYPE = "responseType";
   public static final String BODY_PARAM_RESPONSE_TYPE_TOKEN = "token";
@@ -37,9 +38,9 @@ public class Constants {
   public static final String BODY_PARAM_LOCATION = "location";
   public static final String BODY_PARAM_PARAMS = "params";
   public static final String BODY_PARAM_IS_NEW_USER = "isNewUser";
-  public static final String BODY_PARAM_LOGIN_CHALLENGE = "loginChallenge";
-  public static final String BODY_PARAM_CONSENT_CHALLENGE = "consentChallenge";
-  public static final String BODY_PARAM_CONSENTED_SCOPES = "consentedScopes";
+  public static final String BODY_PARAM_LOGIN_CHALLENGE = "login_challenge";
+  public static final String BODY_PARAM_CONSENT_CHALLENGE = "consent_challenge";
+  public static final String BODY_PARAM_CONSENTED_SCOPES = "consented_scopes";
 
   // User Block Flow Constants
   public static final String BODY_PARAM_USER_IDENTIFIER = "userIdentifier";
@@ -53,11 +54,11 @@ public class Constants {
 
   // Scope Configuration Params
   public static final String BODY_PARAM_SCOPE = "name";
-  public static final String BODY_PARAM_DISPLAY_NAME = "displayName";
+  public static final String BODY_PARAM_DISPLAY_NAME = "display_name";
   public static final String BODY_PARAM_DESCRIPTION = "description";
   public static final String BODY_PARAM_CLAIMS = "claims";
-  public static final String BODY_PARAM_ICON_URL = "iconUrl";
-  public static final String BODY_PARAM_IS_OIDC = "isOidc";
+  public static final String BODY_PARAM_ICON_URL = "icon_url";
+  public static final String BODY_PARAM_IS_OIDC = "is_oidc";
   public static final String BODY_PARAM_OTP = "otp";
 
   public static final String BODY_CHANNEL_EMAIL = "EMAIL";
@@ -80,7 +81,7 @@ public class Constants {
   public static final String SCOPE_PHONE = "phone";
   public static final String SCOPE_EMAIL = "email";
   public static final String SCOPE_ADDRESS = "address";
-  public static final String DISPLAY_NAME = "displayName";
+  public static final String DISPLAY_NAME = "display_name";
 
   // Predefined claim names
   public static final String CLAIM_SUB = "sub";

--- a/src/test/java/com/dreamsportslabs/guardian/it/ConsentAcceptIT.java
+++ b/src/test/java/com/dreamsportslabs/guardian/it/ConsentAcceptIT.java
@@ -7,7 +7,6 @@ import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_DESCRIPTION;
 import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_DISPLAY_NAME;
 import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_IS_OIDC;
 import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_LOGIN_CHALLENGE;
-import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_REFRESH_TOKEN;
 import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_SCOPE;
 import static com.dreamsportslabs.guardian.Constants.CLAIM_ADDRESS;
 import static com.dreamsportslabs.guardian.Constants.CLAIM_EMAIL;
@@ -27,6 +26,7 @@ import static com.dreamsportslabs.guardian.Constants.HEADER_LOCATION;
 import static com.dreamsportslabs.guardian.Constants.IP_ADDRESS;
 import static com.dreamsportslabs.guardian.Constants.LOCATION_VALUE;
 import static com.dreamsportslabs.guardian.Constants.MESSAGE;
+import static com.dreamsportslabs.guardian.Constants.OIDC_BODY_PARAM_REFRESH_TOKEN;
 import static com.dreamsportslabs.guardian.Constants.SCOPE_ADDRESS;
 import static com.dreamsportslabs.guardian.Constants.SCOPE_EMAIL;
 import static com.dreamsportslabs.guardian.Constants.SCOPE_OPENID;
@@ -166,7 +166,7 @@ public class ConsentAcceptIT {
 
     Map<String, Object> loginAcceptBody = new HashMap<>();
     loginAcceptBody.put(BODY_PARAM_LOGIN_CHALLENGE, loginChallenge);
-    loginAcceptBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+    loginAcceptBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
 
     Response loginAcceptResponse = loginAccept(tenant1, loginAcceptBody);
 
@@ -178,7 +178,7 @@ public class ConsentAcceptIT {
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put(BODY_PARAM_CONSENT_CHALLENGE, consentChallenge);
     requestBody.put(BODY_PARAM_CONSENTED_SCOPES, consentedScopes);
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, refreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, refreshToken);
     return requestBody;
   }
 
@@ -315,7 +315,7 @@ public class ConsentAcceptIT {
 
     Map<String, Object> loginAcceptBody = new HashMap<>();
     loginAcceptBody.put(BODY_PARAM_LOGIN_CHALLENGE, loginChallenge);
-    loginAcceptBody.put(BODY_PARAM_REFRESH_TOKEN, testRefreshToken);
+    loginAcceptBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, testRefreshToken);
 
     Response loginAcceptResponse = loginAccept(tenant1, loginAcceptBody);
 
@@ -324,7 +324,7 @@ public class ConsentAcceptIT {
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put(BODY_PARAM_CONSENT_CHALLENGE, consentChallenge);
     requestBody.put(BODY_PARAM_CONSENTED_SCOPES, Arrays.asList(SCOPE_OPENID, SCOPE_ADDRESS));
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, testRefreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, testRefreshToken);
 
     Response response = consentAccept(tenant1, requestBody);
 
@@ -536,7 +536,7 @@ public class ConsentAcceptIT {
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put(BODY_PARAM_CONSENT_CHALLENGE, validConsentChallenge);
     requestBody.put(BODY_PARAM_CONSENTED_SCOPES, Arrays.asList(SCOPE_OPENID, SCOPE_EMAIL));
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
 
     Response response = consentAccept(nonExistentTenant, requestBody);
 
@@ -579,7 +579,7 @@ public class ConsentAcceptIT {
 
     Map<String, Object> loginAcceptBody = new HashMap<>();
     loginAcceptBody.put(BODY_PARAM_LOGIN_CHALLENGE, loginChallenge);
-    loginAcceptBody.put(BODY_PARAM_REFRESH_TOKEN, refreshToken);
+    loginAcceptBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, refreshToken);
 
     Response loginAcceptResponse = loginAccept(tenant2, loginAcceptBody);
 
@@ -590,7 +590,7 @@ public class ConsentAcceptIT {
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put(BODY_PARAM_CONSENT_CHALLENGE, expiredConsentChallenge);
     requestBody.put(BODY_PARAM_CONSENTED_SCOPES, Arrays.asList(SCOPE_OPENID, SCOPE_EMAIL));
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, refreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, refreshToken);
 
     Response response = consentAccept(tenant2, requestBody);
 
@@ -608,7 +608,7 @@ public class ConsentAcceptIT {
     requestBody.put(BODY_PARAM_CONSENT_CHALLENGE, validConsentChallenge);
     requestBody.put(
         BODY_PARAM_CONSENTED_SCOPES, Arrays.asList(SCOPE_OPENID, SCOPE_EMAIL, SCOPE_PHONE));
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
 
     Response response = consentAccept(tenant1, requestBody);
 
@@ -633,7 +633,7 @@ public class ConsentAcceptIT {
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put(BODY_PARAM_CONSENT_CHALLENGE, validConsentChallenge);
     requestBody.put(BODY_PARAM_CONSENTED_SCOPES, Arrays.asList(SCOPE_OPENID, SCOPE_EMAIL));
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, tenant2RefreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, tenant2RefreshToken);
 
     Response response = consentAccept(tenant2, requestBody);
 
@@ -650,7 +650,7 @@ public class ConsentAcceptIT {
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put(BODY_PARAM_CONSENT_CHALLENGE, validConsentChallenge);
     requestBody.put(BODY_PARAM_CONSENTED_SCOPES, Arrays.asList(SCOPE_OPENID, SCOPE_EMAIL));
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
 
     Response response = consentAccept(tenant1, requestBody);
 
@@ -671,7 +671,7 @@ public class ConsentAcceptIT {
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put(BODY_PARAM_CONSENT_CHALLENGE, validConsentChallenge);
     requestBody.put(BODY_PARAM_CONSENTED_SCOPES, Arrays.asList(SCOPE_OPENID));
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
 
     Response response = consentAccept(tenant1, requestBody);
 
@@ -693,7 +693,7 @@ public class ConsentAcceptIT {
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put(BODY_PARAM_CONSENT_CHALLENGE, malformedConsentChallenge);
     requestBody.put(BODY_PARAM_CONSENTED_SCOPES, Arrays.asList(SCOPE_OPENID, SCOPE_EMAIL));
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
 
     Response response = consentAccept(tenant1, requestBody);
 
@@ -711,7 +711,7 @@ public class ConsentAcceptIT {
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put(BODY_PARAM_CONSENT_CHALLENGE, validConsentChallenge);
     requestBody.put(BODY_PARAM_CONSENTED_SCOPES, Arrays.asList(SCOPE_OPENID, SCOPE_EMAIL));
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
 
     Response response = consentAccept(tenant1, requestBody);
 
@@ -730,7 +730,7 @@ public class ConsentAcceptIT {
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put(BODY_PARAM_CONSENT_CHALLENGE, validConsentChallenge);
     requestBody.put(BODY_PARAM_CONSENTED_SCOPES, Arrays.asList(SCOPE_OPENID));
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
 
     Response response = consentAccept(tenant1, requestBody);
 
@@ -751,7 +751,7 @@ public class ConsentAcceptIT {
     requestBody.put(
         BODY_PARAM_CONSENTED_SCOPES,
         Arrays.asList(SCOPE_OPENID, SCOPE_EMAIL, SCOPE_PHONE, SCOPE_ADDRESS));
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
 
     Response response = consentAccept(tenant1, requestBody);
 
@@ -783,7 +783,7 @@ public class ConsentAcceptIT {
 
     Map<String, Object> loginAcceptBody = new HashMap<>();
     loginAcceptBody.put(BODY_PARAM_LOGIN_CHALLENGE, loginChallenge);
-    loginAcceptBody.put(BODY_PARAM_REFRESH_TOKEN, testRefreshToken);
+    loginAcceptBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, testRefreshToken);
 
     Response loginAcceptResponse = loginAccept(tenant1, loginAcceptBody);
 
@@ -794,7 +794,7 @@ public class ConsentAcceptIT {
     requestBody.put(BODY_PARAM_CONSENT_CHALLENGE, consentChallenge);
     requestBody.put(
         BODY_PARAM_CONSENTED_SCOPES, Arrays.asList(SCOPE_OPENID, SCOPE_EMAIL, SCOPE_ADDRESS));
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, testRefreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, testRefreshToken);
 
     Response response = consentAccept(tenant1, requestBody);
 

--- a/src/test/java/com/dreamsportslabs/guardian/it/LoginAcceptIT.java
+++ b/src/test/java/com/dreamsportslabs/guardian/it/LoginAcceptIT.java
@@ -5,7 +5,6 @@ import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_DESCRIPTION;
 import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_DISPLAY_NAME;
 import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_IS_OIDC;
 import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_LOGIN_CHALLENGE;
-import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_REFRESH_TOKEN;
 import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_SCOPE;
 import static com.dreamsportslabs.guardian.Constants.CLAIM_ADDRESS;
 import static com.dreamsportslabs.guardian.Constants.CLAIM_EMAIL;
@@ -28,6 +27,7 @@ import static com.dreamsportslabs.guardian.Constants.HEADER_LOCATION;
 import static com.dreamsportslabs.guardian.Constants.INVALID_TENANT;
 import static com.dreamsportslabs.guardian.Constants.IP_ADDRESS;
 import static com.dreamsportslabs.guardian.Constants.LOCATION_VALUE;
+import static com.dreamsportslabs.guardian.Constants.OIDC_BODY_PARAM_REFRESH_TOKEN;
 import static com.dreamsportslabs.guardian.Constants.PARTIAL_CONSENT_USER_ID;
 import static com.dreamsportslabs.guardian.Constants.SCOPE_ADDRESS;
 import static com.dreamsportslabs.guardian.Constants.SCOPE_EMAIL;
@@ -149,8 +149,10 @@ public class LoginAcceptIT {
   public void testLoginAcceptSuccess() {
     Map<String, Object> requestBody =
         Map.of(
-            BODY_PARAM_LOGIN_CHALLENGE, validLoginChallenge,
-            BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+            BODY_PARAM_LOGIN_CHALLENGE,
+            validLoginChallenge,
+            OIDC_BODY_PARAM_REFRESH_TOKEN,
+            validRefreshToken);
 
     Response response = loginAccept(tenant1, requestBody);
 
@@ -162,7 +164,7 @@ public class LoginAcceptIT {
   @NullAndEmptySource
   void testLoginAcceptNullEmptyLoginChallenge(String loginChallenge) {
     Map<String, Object> requestBody = new HashMap<>();
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
     requestBody.put(BODY_PARAM_LOGIN_CHALLENGE, loginChallenge);
 
     Response response = loginAccept(tenant1, requestBody);
@@ -180,7 +182,7 @@ public class LoginAcceptIT {
   void testLoginAcceptNullEmptyRefreshToken(String refreshToken) {
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put(BODY_PARAM_LOGIN_CHALLENGE, validLoginChallenge);
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, refreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, refreshToken);
 
     Response response = loginAccept(tenant1, requestBody);
 
@@ -198,8 +200,10 @@ public class LoginAcceptIT {
         "invalid_login_challenge_" + RandomStringUtils.randomAlphanumeric(10);
     Map<String, Object> requestBody =
         Map.of(
-            BODY_PARAM_LOGIN_CHALLENGE, invalidLoginChallenge,
-            BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+            BODY_PARAM_LOGIN_CHALLENGE,
+            invalidLoginChallenge,
+            OIDC_BODY_PARAM_REFRESH_TOKEN,
+            validRefreshToken);
 
     Response response = loginAccept(tenant1, requestBody);
 
@@ -217,8 +221,10 @@ public class LoginAcceptIT {
         "invalid_refresh_token_" + RandomStringUtils.randomAlphanumeric(10);
     Map<String, Object> requestBody =
         Map.of(
-            BODY_PARAM_LOGIN_CHALLENGE, validLoginChallenge,
-            BODY_PARAM_REFRESH_TOKEN, invalidRefreshToken);
+            BODY_PARAM_LOGIN_CHALLENGE,
+            validLoginChallenge,
+            OIDC_BODY_PARAM_REFRESH_TOKEN,
+            invalidRefreshToken);
 
     Response response = loginAccept(tenant1, requestBody);
 
@@ -234,7 +240,7 @@ public class LoginAcceptIT {
   public void testLoginAcceptMissingTenantId() {
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put(BODY_PARAM_LOGIN_CHALLENGE, validLoginChallenge);
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
 
     Response response = loginAccept(null, requestBody);
 
@@ -246,7 +252,7 @@ public class LoginAcceptIT {
   public void testLoginAcceptNonExistentTenantId() {
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put(BODY_PARAM_LOGIN_CHALLENGE, validLoginChallenge);
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
 
     Response response = loginAccept(INVALID_TENANT, requestBody);
 
@@ -279,8 +285,10 @@ public class LoginAcceptIT {
 
     Map<String, Object> requestBody =
         Map.of(
-            BODY_PARAM_LOGIN_CHALLENGE, skipConsentLoginChallenge,
-            BODY_PARAM_REFRESH_TOKEN, skipConsentRefreshToken);
+            BODY_PARAM_LOGIN_CHALLENGE,
+            skipConsentLoginChallenge,
+            OIDC_BODY_PARAM_REFRESH_TOKEN,
+            skipConsentRefreshToken);
 
     Response response = loginAccept(tenant1, requestBody);
 
@@ -311,8 +319,10 @@ public class LoginAcceptIT {
 
     Map<String, Object> requestBody =
         Map.of(
-            BODY_PARAM_LOGIN_CHALLENGE, validLoginChallenge,
-            BODY_PARAM_REFRESH_TOKEN, partialConsentRefreshToken);
+            BODY_PARAM_LOGIN_CHALLENGE,
+            validLoginChallenge,
+            OIDC_BODY_PARAM_REFRESH_TOKEN,
+            partialConsentRefreshToken);
 
     Response response = loginAccept(tenant1, requestBody);
 
@@ -324,7 +334,7 @@ public class LoginAcceptIT {
   public void testLoginAcceptConcurrentRequests() {
     Map<String, Object> requestBody = new HashMap<>();
     requestBody.put(BODY_PARAM_LOGIN_CHALLENGE, validLoginChallenge);
-    requestBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+    requestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
 
     Response response1 = loginAccept(tenant1, requestBody);
     Response response2 = loginAccept(tenant1, requestBody);
@@ -345,8 +355,10 @@ public class LoginAcceptIT {
         "expired_login_challenge_" + RandomStringUtils.randomAlphanumeric(10);
     Map<String, Object> requestBody =
         Map.of(
-            BODY_PARAM_LOGIN_CHALLENGE, expiredLoginChallenge,
-            BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+            BODY_PARAM_LOGIN_CHALLENGE,
+            expiredLoginChallenge,
+            OIDC_BODY_PARAM_REFRESH_TOKEN,
+            validRefreshToken);
 
     Response response = loginAccept(tenant1, requestBody);
 
@@ -366,8 +378,10 @@ public class LoginAcceptIT {
 
     Map<String, Object> requestBody =
         Map.of(
-            BODY_PARAM_LOGIN_CHALLENGE, validLoginChallenge,
-            BODY_PARAM_REFRESH_TOKEN, expiredRefreshToken);
+            BODY_PARAM_LOGIN_CHALLENGE,
+            validLoginChallenge,
+            OIDC_BODY_PARAM_REFRESH_TOKEN,
+            expiredRefreshToken);
 
     Response response = loginAccept(tenant1, requestBody);
 
@@ -383,8 +397,10 @@ public class LoginAcceptIT {
   public void testLoginAcceptTenantIsolation() {
     Map<String, Object> requestBody =
         Map.of(
-            BODY_PARAM_LOGIN_CHALLENGE, validLoginChallenge,
-            BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+            BODY_PARAM_LOGIN_CHALLENGE,
+            validLoginChallenge,
+            OIDC_BODY_PARAM_REFRESH_TOKEN,
+            validRefreshToken);
 
     Response response = loginAccept(tenant2, requestBody);
 
@@ -414,8 +430,10 @@ public class LoginAcceptIT {
 
     Map<String, Object> requestBody =
         Map.of(
-            BODY_PARAM_LOGIN_CHALLENGE, validLoginChallenge,
-            BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+            BODY_PARAM_LOGIN_CHALLENGE,
+            validLoginChallenge,
+            OIDC_BODY_PARAM_REFRESH_TOKEN,
+            validRefreshToken);
 
     Response response = loginAccept(tenant1, requestBody);
 
@@ -437,8 +455,10 @@ public class LoginAcceptIT {
 
     Map<String, Object> requestBody =
         Map.of(
-            BODY_PARAM_LOGIN_CHALLENGE, validLoginChallenge,
-            BODY_PARAM_REFRESH_TOKEN, malformedRefreshToken);
+            BODY_PARAM_LOGIN_CHALLENGE,
+            validLoginChallenge,
+            OIDC_BODY_PARAM_REFRESH_TOKEN,
+            malformedRefreshToken);
 
     Response response = loginAccept(tenant1, requestBody);
 
@@ -455,8 +475,10 @@ public class LoginAcceptIT {
     // This test ensures the async deletion handles null gracefully
     Map<String, Object> requestBody =
         Map.of(
-            BODY_PARAM_LOGIN_CHALLENGE, validLoginChallenge,
-            BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+            BODY_PARAM_LOGIN_CHALLENGE,
+            validLoginChallenge,
+            OIDC_BODY_PARAM_REFRESH_TOKEN,
+            validRefreshToken);
 
     Response response = loginAccept(tenant1, requestBody);
 
@@ -472,8 +494,10 @@ public class LoginAcceptIT {
 
     Map<String, Object> requestBody =
         Map.of(
-            BODY_PARAM_LOGIN_CHALLENGE, validLoginChallenge,
-            BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+            BODY_PARAM_LOGIN_CHALLENGE,
+            validLoginChallenge,
+            OIDC_BODY_PARAM_REFRESH_TOKEN,
+            validRefreshToken);
 
     Response response = loginAccept(tenant1, requestBody);
 

--- a/src/test/java/com/dreamsportslabs/guardian/it/OidcTokenIT.java
+++ b/src/test/java/com/dreamsportslabs/guardian/it/OidcTokenIT.java
@@ -13,7 +13,6 @@ import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_EMAIL;
 import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_IS_OIDC;
 import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_LOGIN_CHALLENGE;
 import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_NAME;
-import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_REFRESH_TOKEN;
 import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_SCOPE;
 import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_USERID;
 import static com.dreamsportslabs.guardian.Constants.BODY_PARAM_USERNAME;
@@ -50,6 +49,7 @@ import static com.dreamsportslabs.guardian.Constants.INVALID_REFRESH_TOKEN;
 import static com.dreamsportslabs.guardian.Constants.INVALID_REQUEST;
 import static com.dreamsportslabs.guardian.Constants.IP_ADDRESS;
 import static com.dreamsportslabs.guardian.Constants.LOCATION_VALUE;
+import static com.dreamsportslabs.guardian.Constants.OIDC_BODY_PARAM_REFRESH_TOKEN;
 import static com.dreamsportslabs.guardian.Constants.PARAM_CODE_CHALLENGE;
 import static com.dreamsportslabs.guardian.Constants.PARAM_CODE_CHALLENGE_METHOD;
 import static com.dreamsportslabs.guardian.Constants.PRAGMA_NO_CACHE;
@@ -313,17 +313,17 @@ public class OidcTokenIT {
 
     Map<String, Object> loginAcceptBody = new HashMap<>();
     loginAcceptBody.put(BODY_PARAM_LOGIN_CHALLENGE, loginChallenge);
-    loginAcceptBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+    loginAcceptBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
 
     Response loginAcceptResponse = loginAccept(tenant1, loginAcceptBody);
 
     loginAcceptBody.put(BODY_PARAM_LOGIN_CHALLENGE, loginChallengeWithCodeChallengeMethodPlain);
-    loginAcceptBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshTokenForUser2);
+    loginAcceptBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshTokenForUser2);
     Response loginAcceptResponseWithCodeChallengeMethodPlain =
         loginAccept(tenant1, loginAcceptBody);
 
     loginAcceptBody.put(BODY_PARAM_LOGIN_CHALLENGE, loginChallengeWithCodeChallengeMethodS256);
-    loginAcceptBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshTokenForUser3);
+    loginAcceptBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshTokenForUser3);
     Response loginAcceptResponseWithCodeChallengeMethodS256 = loginAccept(tenant1, loginAcceptBody);
 
     validConsentChallenge = extractConsentChallenge(loginAcceptResponse);
@@ -336,14 +336,14 @@ public class OidcTokenIT {
     consentRequestBody.put(BODY_PARAM_CONSENT_CHALLENGE, validConsentChallenge);
     consentRequestBody.put(
         BODY_PARAM_CONSENTED_SCOPES, Arrays.asList(SCOPE_OPENID, SCOPE_EMAIL, SCOPE_PHONE));
-    consentRequestBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
+    consentRequestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshToken);
 
     Response consentAcceptResponse = consentAccept(tenant1, consentRequestBody);
     validAuthCode = extractAuthCodeFromLocation(consentAcceptResponse.getHeader(HEADER_LOCATION));
 
     consentRequestBody.put(
         BODY_PARAM_CONSENT_CHALLENGE, validConsentChallengeWithCodeChallengeMethodPlain);
-    consentRequestBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshTokenForUser2);
+    consentRequestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshTokenForUser2);
 
     Response consentAcceptResponseWithCodeChallengeMethodPlain =
         consentAccept(tenant1, consentRequestBody);
@@ -353,7 +353,7 @@ public class OidcTokenIT {
 
     consentRequestBody.put(
         BODY_PARAM_CONSENT_CHALLENGE, validConsentChallengeWithCodeChallengeMethodS256);
-    consentRequestBody.put(BODY_PARAM_REFRESH_TOKEN, validRefreshTokenForUser3);
+    consentRequestBody.put(OIDC_BODY_PARAM_REFRESH_TOKEN, validRefreshTokenForUser3);
 
     Response consentAcceptResponseWithCodeChallengeMethodS256 =
         consentAccept(tenant1, consentRequestBody);

--- a/src/test/java/com/dreamsportslabs/guardian/utils/DbUtils.java
+++ b/src/test/java/com/dreamsportslabs/guardian/utils/DbUtils.java
@@ -73,14 +73,14 @@ public class DbUtils {
       if (resultSet.next()) {
         JsonObject scope = new JsonObject();
         scope.put("name", resultSet.getString("name"));
-        scope.put("displayName", resultSet.getString("display_name"));
+        scope.put("display_name", resultSet.getString("display_name"));
         scope.put("description", resultSet.getString("description"));
         scope.put(
             "claims",
             resultSet.getString("claims").equals("[]") ? null : resultSet.getString("claims"));
         scope.put("tenantId", resultSet.getString("tenant_id"));
-        scope.put("iconUrl", resultSet.getString("icon_url"));
-        scope.put("isOidc", resultSet.getBoolean("is_oidc"));
+        scope.put("icon_url", resultSet.getString("icon_url"));
+        scope.put("is_oidc", resultSet.getBoolean("is_oidc"));
         return scope;
       } else {
         return null;


### PR DESCRIPTION
- This PR introduces a modification in current request and response format for Scope, ConsentAccept and LoginAccept APIs
- Now the request payload and response will both contain keys in snake_case.
