### PR TITLE
Added new column in fb_config to handle app_secret

### DIFF
--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/FbConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/FbConfig.java
@@ -6,5 +6,5 @@ import lombok.Data;
 public class FbConfig {
   private String appId;
   private String appSecret;
-  private Boolean appSecretRequired;
+  private Boolean sendAppSecret;
 }

--- a/src/main/java/com/dreamsportslabs/guardian/dao/query/ConfigQuery.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/query/ConfigQuery.java
@@ -51,7 +51,7 @@ public class ConfigQuery {
       """
     SELECT app_id,
            app_secret,
-           app_secret_required
+           send_app_secret
     FROM fb_config
     WHERE tenant_id = ?
     """;

--- a/src/main/java/com/dreamsportslabs/guardian/service/impl/idproviders/FacebookIdProvider.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/impl/idproviders/FacebookIdProvider.java
@@ -20,20 +20,20 @@ import org.apache.commons.lang3.StringUtils;
 public class FacebookIdProvider implements IdProvider {
   private final WebClient webClient;
   private final String appSecret;
-  private final Boolean appSecretRequired;
+  private final Boolean sendAppSecret;
   private final String fields = "id,name,first_name,middle_name,last_name,email,picture";
 
   public FacebookIdProvider(FbConfig fbConfigDto) {
     this.webClient = GuiceInjector.getGuiceInjector().getInstance(WebClient.class);
     this.appSecret = fbConfigDto.getAppSecret();
-    this.appSecretRequired = fbConfigDto.getAppSecretRequired();
+    this.sendAppSecret = fbConfigDto.getSendAppSecret();
   }
 
   @Override
   public Single<JsonObject> getUserIdentity(String accessToken) {
     HttpRequest<Buffer> request = webClient.get(443, "graph.facebook.com", "/me");
 
-    if (this.appSecretRequired) {
+    if (this.sendAppSecret) {
       String appSecretProof =
           Hashing.hmacSha256(this.appSecret.getBytes())
               .hashString(accessToken, StandardCharsets.UTF_8)

--- a/src/main/resources/migrations/01_migrationFile.sql
+++ b/src/main/resources/migrations/01_migrationFile.sql
@@ -85,7 +85,7 @@ CREATE TABLE fb_config
     tenant_id           CHAR(10)     PRIMARY KEY,
     app_id              VARCHAR(256) NOT NULL,
     app_secret          VARCHAR(256) NOT NULL,
-    app_secret_required BOOLEAN      NOT NULL DEFAULT TRUE,
+    send_app_secret     BOOLEAN      NOT NULL DEFAULT TRUE,
     created_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at          TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 


### PR DESCRIPTION
- Added column`app_secret_required` with type `boolean` in table `fb_config` to handle whether the `app_secret` is required to call the fb me query. 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request adds a new boolean column, app_secret_required, to the fb_config table for improved management of app secret requirements during Facebook authentication. It updates the FbConfig class and modifies the SQL query and FacebookIdProvider service to enhance flexibility and security in the authentication process.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-defined, making the review process relatively simple.
-->
</div>