### PR TITLE
Changed endpoint to v1/revocations

### DIFF
--- a/src/main/java/com/dreamsportslabs/guardian/rest/Revocations.java
+++ b/src/main/java/com/dreamsportslabs/guardian/rest/Revocations.java
@@ -18,7 +18,7 @@ import java.util.concurrent.CompletionStage;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor(onConstructor = @__({@Inject}))
-@Path("/revocations")
+@Path("/v1/revocations")
 public class Revocations {
   private final RevocationService revocationService;
 


### PR DESCRIPTION
- Revocations API endpoint changed from `/revocations` to `v1/revocations` 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request updates the Revocations API endpoint by changing its path from '/revocations' to '/v1/revocations', enhancing versioning for better API management and backward compatibility.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and primarily involve path updates, making the review process relatively simple.
-->
</div>