### PR TITLE
validate nonce claim only if sent in request

### DIFF
--- a/src/main/java/com/dreamsportslabs/guardian/service/IdpConnectService.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/IdpConnectService.java
@@ -306,7 +306,7 @@ public class IdpConnectService {
     String requestNonce = idpConnectRequestDto.getNonce();
     if (StringUtils.isNotBlank(requestNonce)) {
       Object nonceClaim = claims.get(OIDC_NONCE);
-      if (nonceClaim == null || !requestNonce.equals(nonceClaim.toString())) {
+      if (!requestNonce.isBlank() && !requestNonce.equals(nonceClaim.toString())) {
         throw INVALID_IDP_TOKEN.getException();
       }
     }


### PR DESCRIPTION
In IDP Connect, validate nonce claim only if sent in the request.