### PR TITLE
fix: config parsing issue

### DIFF
--- a/src/main/java/com/dreamsportslabs/guardian/verticle/MainVerticle.java
+++ b/src/main/java/com/dreamsportslabs/guardian/verticle/MainVerticle.java
@@ -114,10 +114,12 @@ public class MainVerticle extends AbstractVerticle {
         new WebClientOptions()
             .setConnectTimeout(Integer.parseInt(config.getString(HTTP_CONNECT_TIMEOUT)))
             .setIdleTimeoutUnit(TimeUnit.MILLISECONDS)
-            .setKeepAlive(config.getBoolean(HTTP_CLIENT_KEEP_ALIVE))
-            .setKeepAliveTimeout(config.getInteger(HTTP_CLIENT_KEEP_ALIVE_TIMEOUT) / 1000)
-            .setIdleTimeout(config.getInteger(HTTP_CLIENT_IDLE_TIMEOUT))
-            .setMaxPoolSize(config.getInteger(HTTP_CLIENT_CONNECTION_POOL_MAX_SIZE))
+            .setKeepAlive(Boolean.parseBoolean(config.getString(HTTP_CLIENT_KEEP_ALIVE)))
+            .setKeepAliveTimeout(
+                Integer.parseInt(config.getString(HTTP_CLIENT_KEEP_ALIVE_TIMEOUT)) / 1000)
+            .setIdleTimeout(Integer.parseInt(config.getString(HTTP_CLIENT_IDLE_TIMEOUT)))
+            .setMaxPoolSize(
+                Integer.parseInt(config.getString(HTTP_CLIENT_CONNECTION_POOL_MAX_SIZE)))
             .setReadIdleTimeout(Integer.parseInt(config.getString(HTTP_READ_TIMEOUT)))
             .setWriteIdleTimeout(Integer.parseInt(config.getString(HTTP_WRITE_TIMEOUT)));
     this.webClient = WebClient.create(vertx, options);


### PR DESCRIPTION
 ## Fix HTTP Client Configuration Parsing

### Problem
HTTP client configuration values were being parsed incorrectly, causing potential runtime errors when reading configuration from environment variables or config files.

### Solution
Updated configuration parsing in MainVerticle.java to use consistent string-based parsing approach:

• Changed config.getBoolean() to Boolean.parseBoolean(config.getString()) for keep-alive setting
• Changed config.getInteger() to Integer.parseInt(config.getString()) for timeout and pool size settings
• Maintains consistency with existing configuration parsing pattern used throughout the codebase

### Impact
Ensures HTTP client configurations are properly read from environment variables and config files without type conversion errors.