### PR TITLE
add Data annotation for passwordPinBlockConfig instead of value

### DIFF
--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/PasswordPinBlockConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/PasswordPinBlockConfig.java
@@ -1,19 +1,11 @@
 package com.dreamsportslabs.guardian.config.tenant;
 
-import lombok.Builder;
 import lombok.Data;
-import lombok.extern.jackson.Jacksonized;
 
 @Data
-@Builder
-@Jacksonized
 public class PasswordPinBlockConfig {
 
-  public static final int DEFAULT_ATTEMPTS_ALLOWED = 5;
-  public static final int DEFAULT_ATTEMPTS_WINDOW_SECONDS = 86400;
-  public static final int DEFAULT_BLOCK_INTERVAL_SECONDS = 86400;
-
-  @Builder.Default int attemptsAllowed = DEFAULT_ATTEMPTS_ALLOWED;
-  @Builder.Default int attemptsWindowSeconds = DEFAULT_ATTEMPTS_WINDOW_SECONDS;
-  @Builder.Default int blockIntervalSeconds = DEFAULT_BLOCK_INTERVAL_SECONDS;
+  private Integer attemptsAllowed;
+  private Integer attemptsWindowSeconds;
+  private Integer blockIntervalSeconds;
 }

--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/PasswordPinBlockConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/PasswordPinBlockConfig.java
@@ -1,10 +1,10 @@
 package com.dreamsportslabs.guardian.config.tenant;
 
 import lombok.Builder;
-import lombok.Value;
+import lombok.Data;
 import lombok.extern.jackson.Jacksonized;
 
-@Value
+@Data
 @Builder
 @Jacksonized
 public class PasswordPinBlockConfig {

--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/PasswordPinBlockConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/PasswordPinBlockConfig.java
@@ -5,7 +5,7 @@ import lombok.Data;
 @Data
 public class PasswordPinBlockConfig {
 
-  private Integer attemptsAllowed;
-  private Integer attemptsWindowSeconds;
-  private Integer blockIntervalSeconds;
+  private int attemptsAllowed;
+  private int attemptsWindowSeconds;
+  private int blockIntervalSeconds;
 }

--- a/src/main/java/com/dreamsportslabs/guardian/config/tenant/TenantConfig.java
+++ b/src/main/java/com/dreamsportslabs/guardian/config/tenant/TenantConfig.java
@@ -10,6 +10,7 @@ import static com.dreamsportslabs.guardian.exception.ErrorEnum.GUEST_LOGIN_NOT_C
 import static com.dreamsportslabs.guardian.exception.ErrorEnum.OIDC_CONFIG_NOT_EXISTS;
 import static com.dreamsportslabs.guardian.exception.ErrorEnum.OIDC_PROVIDER_NOT_CONFIGURED;
 import static com.dreamsportslabs.guardian.exception.ErrorEnum.OTP_NOT_CONFIGURED;
+import static com.dreamsportslabs.guardian.exception.ErrorEnum.PASSWORD_PIN_BLOCK_NOT_CONFIGURED;
 import static com.dreamsportslabs.guardian.exception.ErrorEnum.SMS_NOT_CONFIGURED;
 
 import java.util.Map;
@@ -116,15 +117,18 @@ public class TenantConfig {
     return guestConfig;
   }
 
+  public PasswordPinBlockConfig getPasswordPinBlockConfig() {
+    if (passwordPinBlockConfig == null) {
+      throw PASSWORD_PIN_BLOCK_NOT_CONFIGURED.getException();
+    }
+    return passwordPinBlockConfig;
+  }
+
   public Optional<FbConfig> findFbConfig() {
     return Optional.ofNullable(fbConfig);
   }
 
   public Optional<GoogleConfig> findGoogleConfig() {
     return Optional.ofNullable(googleConfig);
-  }
-
-  public Optional<PasswordPinBlockConfig> findPasswordPinBlockConfig() {
-    return Optional.ofNullable(passwordPinBlockConfig);
   }
 }

--- a/src/main/java/com/dreamsportslabs/guardian/dao/ConfigDao.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/ConfigDao.java
@@ -109,7 +109,7 @@ public class ConfigDao {
         .ignoreElement()
         .onErrorResumeNext(
             e -> {
-              log.warn(
+              log.info(
                   "Failed to load password_pin_block_config for tenant {}: {}",
                   tenantId,
                   e.getMessage());

--- a/src/main/java/com/dreamsportslabs/guardian/dao/ConfigDao.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/ConfigDao.java
@@ -106,15 +106,7 @@ public class ConfigDao {
     return getOptionalConfigFromDb(
             tenantId, PasswordPinBlockConfig.class, PASSWORD_PIN_BLOCK_CONFIG)
         .map(builder::passwordPinBlockConfig)
-        .ignoreElement()
-        .onErrorResumeNext(
-            e -> {
-              log.info(
-                  "Failed to load password_pin_block_config for tenant {}: {}",
-                  tenantId,
-                  e.getMessage());
-              return Completable.complete();
-            });
+        .ignoreElement();
   }
 
   private Completable appendUserConfig(String tenantId, TenantConfig.TenantConfigBuilder builder) {

--- a/src/main/java/com/dreamsportslabs/guardian/dao/ConfigDao.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/ConfigDao.java
@@ -106,7 +106,15 @@ public class ConfigDao {
     return getOptionalConfigFromDb(
             tenantId, PasswordPinBlockConfig.class, PASSWORD_PIN_BLOCK_CONFIG)
         .map(builder::passwordPinBlockConfig)
-        .ignoreElement();
+        .ignoreElement()
+        .onErrorResumeNext(
+            e -> {
+              log.warn(
+                  "Failed to load password_pin_block_config for tenant {}: {}",
+                  tenantId,
+                  e.getMessage());
+              return Completable.complete();
+            });
   }
 
   private Completable appendUserConfig(String tenantId, TenantConfig.TenantConfigBuilder builder) {

--- a/src/main/java/com/dreamsportslabs/guardian/exception/ErrorEnum.java
+++ b/src/main/java/com/dreamsportslabs/guardian/exception/ErrorEnum.java
@@ -88,6 +88,8 @@ public enum ErrorEnum {
       400),
   GUEST_LOGIN_NOT_CONFIGURED(
       "guest_login_not_configured", "Guest login is not configured for this tenant", 400),
+  PASSWORD_PIN_BLOCK_NOT_CONFIGURED(
+      "password_pin_block_not_configured", "Password pin block is not configured", 400),
   AUTH_CODE_NOT_CONFIGURED(
       "auth_code_not_configured",
       "Authorization code feature is not configured for this tenant",

--- a/src/main/java/com/dreamsportslabs/guardian/service/PasswordAuth.java
+++ b/src/main/java/com/dreamsportslabs/guardian/service/PasswordAuth.java
@@ -226,15 +226,9 @@ public class PasswordAuth {
         .map(
             config ->
                 new BlockConfig(
-                    config.getAttemptsAllowed() != null
-                        ? config.getAttemptsAllowed()
-                        : DEFAULT_ATTEMPTS_ALLOWED,
-                    config.getAttemptsWindowSeconds() != null
-                        ? config.getAttemptsWindowSeconds()
-                        : DEFAULT_ATTEMPTS_WINDOW_SECONDS,
-                    config.getBlockIntervalSeconds() != null
-                        ? config.getBlockIntervalSeconds()
-                        : DEFAULT_BLOCK_INTERVAL_SECONDS))
+                    config.getAttemptsAllowed(),
+                    config.getAttemptsWindowSeconds(),
+                    config.getBlockIntervalSeconds()))
         .orElseGet(
             () ->
                 new BlockConfig(

--- a/src/main/resources/oas/guardian.yaml
+++ b/src/main/resources/oas/guardian.yaml
@@ -205,11 +205,18 @@ paths:
                 items:
                   type: string
         '400':
-          description: Bad Request due to missing parameters or invalid data
+          description: Bad Request due to missing parameters, invalid data, or missing config
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                password_pin_block_not_configured:
+                  summary: Password pin block not configured
+                  value:
+                    error:
+                      code: "password_pin_block_not_configured"
+                      message: "Password pin block is not configured"
         '403':
           description: Forbidden - User's flow is blocked due to too many failed attempts
           content:
@@ -497,11 +504,18 @@ paths:
                 oneOf:
                   - $ref: '#/components/schemas/TokenResponse'
         '400':
-          description: Bad Request due to missing parameters or invalid data
+          description: Bad Request due to missing parameters, invalid data, or missing config
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                password_pin_block_not_configured:
+                  summary: Password pin block not configured
+                  value:
+                    error:
+                      code: "password_pin_block_not_configured"
+                      message: "Password pin block is not configured"
         '500':
           description: Internal Server Error
           content:


### PR DESCRIPTION
## Description
password_pin_block_config is now treated like other optional configs (otp, sms, email): it is not created on tenant creation, is loaded optionally, and sign-in fails with a clear error when it is missing.

## Sign-in behavior
- TenantConfig.getPasswordPinBlockConfig() throws PASSWORD_PIN_BLOCK_NOT_CONFIGURED (400) when the config is null.
- Sign-in APIs (/v1/signin, /v2/signin) return 400 with password_pin_block_not_configured when the tenant has no config.
- Tenants that use sign-in must configure password_pin_block_config via the admin API first.
