### PR TITLE
chore: fix intermittent config unavailablity issue fixed

### DIFF
--- a/src/main/java/com/dreamsportslabs/guardian/dao/ConfigDao.java
+++ b/src/main/java/com/dreamsportslabs/guardian/dao/ConfigDao.java
@@ -70,8 +70,8 @@ public class ConfigDao {
             appendOidcConfig(tenantId, builder),
             appendGuestConfig(tenantId, builder));
 
-    return Completable.merge(mandatoryConfigSources)
-        .andThen(Completable.merge(optionalConfigSources).onErrorComplete())
+    return Completable.concat(mandatoryConfigSources)
+        .andThen(Completable.concat(optionalConfigSources).onErrorComplete())
         .andThen(Single.defer(() -> Single.just(builder.build())));
   }
 


### PR DESCRIPTION
## Summary
- Fixed race condition in `ConfigDao.getTenantConfig()` that caused intermittent "config not found" errors
- Changed from parallel (`merge`) to sequential (`concat`) execution of config loading operations

## Problem
Tenant configuration loading was failing intermittently with errors like:
- `email_not_configured`
- `otp_not_configured`
- `sms_not_configured`

The issue occurred randomly - sometimes on the first request, sometimes after 20-30 requests - even though all configurations existed in the database.

## Root Cause
`Completable.merge()` executes operations in parallel on multiple threads. Each operation was writing to a shared, non-thread-safe `TenantConfig.TenantConfigBuilder` instance. This caused a **memory visibility issue** where:
1. Multiple threads wrote config values to the builder concurrently
2. Due to Java Memory Model semantics, some writes were not visible to the thread calling `builder.build()`
3. The resulting `TenantConfig` object had some fields as `null`

## Solution
Changed `Completable.merge()` to `Completable.concat()` to ensure sequential execution:

``` 
// Before (parallel - unsafe)
return Completable.merge(mandatoryConfigSources)
    .andThen(Completable.merge(optionalConfigSources).onErrorComplete())
```

```
// After (sequential - safe)
return Completable.concat(mandatoryConfigSources)
    .andThen(Completable.concat(optionalConfigSources).onErrorComplete())

```
